### PR TITLE
feat: Add keyboard shortcuts to switch between Videos, Shopping, News…

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -168,6 +168,50 @@ import {
           window.location.href = allSearchUrl;
         }
       }
+    } else if (keymapManager.isKeyMatch(e, 'switch_to_videos')) {
+      // switch to videos tab
+      e.preventDefault();
+      if (searchTabType !== 'videos') {
+        const searchParams = new URLSearchParams(window.location.search);
+        const query = searchParams.get('q');
+        if (query) {
+          const videosUrl = `https://www.google.com/search?tbm=vid&q=${encodeURIComponent(query)}`;
+          window.location.href = videosUrl;
+        }
+      }
+    } else if (keymapManager.isKeyMatch(e, 'switch_to_shopping')) {
+      // switch to shopping tab
+      e.preventDefault();
+      if (searchTabType !== 'shopping') {
+        const searchParams = new URLSearchParams(window.location.search);
+        const query = searchParams.get('q');
+        if (query) {
+          const shoppingUrl = `https://www.google.com/search?tbm=shop&q=${encodeURIComponent(query)}`;
+          window.location.href = shoppingUrl;
+        }
+      }
+    } else if (keymapManager.isKeyMatch(e, 'switch_to_news')) {
+      // switch to news tab
+      e.preventDefault();
+      if (searchTabType !== 'news') {
+        const searchParams = new URLSearchParams(window.location.search);
+        const query = searchParams.get('q');
+        if (query) {
+          const newsUrl = `https://www.google.com/search?tbm=nws&q=${encodeURIComponent(query)}`;
+          window.location.href = newsUrl;
+        }
+      }
+    } else if (keymapManager.isKeyMatch(e, 'switch_to_map')) {
+      // switch to map tab
+      e.preventDefault();
+      if (searchTabType !== 'map') {
+        const searchParams = new URLSearchParams(window.location.search);
+        const query = searchParams.get('q');
+        if (query) {
+          const mapUrl = `https://www.google.com/maps/search/${encodeURIComponent(query)}`;
+          window.location.href = mapUrl;
+        }
+      }
     }
   });
 })();

--- a/src/key-map-manager.ts
+++ b/src/key-map-manager.ts
@@ -17,6 +17,10 @@ export interface KeyConfigs<T extends string> {
   navigate_next: KeyConfig<T>;
   switch_to_image_search: KeyConfig<T>;
   switch_to_all_search: KeyConfig<T>;
+  switch_to_videos: KeyConfig<T>;
+  switch_to_shopping: KeyConfig<T>;
+  switch_to_news: KeyConfig<T>;
+  switch_to_map: KeyConfig<T>;
 }
 
 export type Action = keyof KeyConfigs<string>;
@@ -66,6 +70,34 @@ export const defaultKeyConfigs: KeyConfigs<string> = {
   },
   switch_to_all_search: {
     key: 'a',
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+  },
+  switch_to_videos: {
+    key: 'v',
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+  },
+  switch_to_shopping: {
+    key: 's',
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+  },
+  switch_to_news: {
+    key: 'n',
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+  },
+  switch_to_map: {
+    key: 'm',
     ctrl: false,
     alt: false,
     shift: false,

--- a/src/popup.html
+++ b/src/popup.html
@@ -225,6 +225,47 @@
         />
       </div>
 
+      <div class="shortcut-row">
+        <div class="shortcut-label">Switch to videos</div>
+        <input
+          type="text"
+          id="switchToVideos"
+          class="shortcut-input"
+          maxlength="1"
+          value="v"
+        />
+      </div>
+      <div class="shortcut-row">
+        <div class="shortcut-label">Switch to shopping</div>
+        <input
+          type="text"
+          id="switchToShopping"
+          class="shortcut-input"
+          maxlength="1"
+          value="s"
+        />
+      </div>
+      <div class="shortcut-row">
+        <div class="shortcut-label">Switch to news</div>
+        <input
+          type="text"
+          id="switchToNews"
+          class="shortcut-input"
+          maxlength="1"
+          value="n"
+        />
+      </div>
+      <div class="shortcut-row">
+        <div class="shortcut-label">Switch to map</div>
+        <input
+          type="text"
+          id="switchToMap"
+          class="shortcut-input"
+          maxlength="1"
+          value="m"
+        />
+      </div>
+
       <div class="button-container">
         <button id="reset" style="margin-right: 8px; background-color: #aaa">
           Reset

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -39,6 +39,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       nextPageInput,
       switchToImageSearchInput,
       switchToAllSearchInput,
+      switchToVideosInput,
+      switchToShoppingInput,
+      switchToNewsInput,
+      switchToMapInput
     ] = [
       MOVE_UP_ID,
       MOVE_DOWN_ID,
@@ -47,6 +51,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       NAVIGATE_NEXT_ID,
       SWITCH_TO_IMAGE_SEARCH_ID,
       SWITCH_TO_ALL_SEARCH_ID,
+      'switchToVideos',
+      'switchToShopping',
+      'switchToNews',
+      'switchToMap'
     ].map((id) => {
       const el = document.getElementById(id);
       if (!el) {
@@ -69,6 +77,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     switchToAllSearchInput.value = keyConfigToString(
       keyConfigs.switch_to_all_search
     );
+    switchToVideosInput.value = keyConfigToString(keyConfigs.switch_to_videos);
+    switchToShoppingInput.value = keyConfigToString(keyConfigs.switch_to_shopping);
+    switchToNewsInput.value = keyConfigToString(keyConfigs.switch_to_news);
+    switchToMapInput.value = keyConfigToString(keyConfigs.switch_to_map);
   }
 
   /**
@@ -93,7 +105,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       // ToDo: need test for key down
       input.addEventListener('keydown', (event) => {
-        // keys that we swallow and wait for a “real” key
+        // keys that we swallow and wait for a "real" key
         const swallowKeys = new Set([
           'Shift',
           'Control',
@@ -103,7 +115,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // 0) If it's a pure modifier, just swallow it—don't blur.
         if (swallowKeys.has(event.key)) {
           event.preventDefault();
-          return; // stay in the input, wait for a “real” key
+          return; // stay in the input, wait for a "real" key
         }
 
         // 1) whitelist test
@@ -191,6 +203,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       nextPageInput,
       switchToImageSearchInput,
       switchToAllSearchInput,
+      switchToVideosInput,
+      switchToShoppingInput,
+      switchToNewsInput,
+      switchToMapInput
     ] = [
       MOVE_DOWN_ID,
       MOVE_UP_ID,
@@ -199,6 +215,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       NAVIGATE_NEXT_ID,
       SWITCH_TO_IMAGE_SEARCH_ID,
       SWITCH_TO_ALL_SEARCH_ID,
+      'switchToVideos',
+      'switchToShopping',
+      'switchToNews',
+      'switchToMap'
     ].map((id) => {
       const el = document.getElementById(id);
       if (!el) {
@@ -217,6 +237,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       navigate_next: nextPageInput,
       switch_to_image_search: switchToImageSearchInput,
       switch_to_all_search: switchToAllSearchInput,
+      switch_to_videos: switchToVideosInput,
+      switch_to_shopping: switchToShoppingInput,
+      switch_to_news: switchToNewsInput,
+      switch_to_map: switchToMapInput
     };
 
     const userOverrideConfigs = (

--- a/src/ui-handler.ts
+++ b/src/ui-handler.ts
@@ -34,7 +34,9 @@ export function getGoogleSearchResultsWithDivG(): HTMLElement[] {
   return Array.from(document.querySelectorAll('div.g'));
 }
 
-export function getGoogleSearchResultsWithH3(tabType: 'all' | 'image') {
+export function getGoogleSearchResultsWithH3(
+  tabType: 'all' | 'image' | 'videos' | 'shopping' | 'news'
+) {
   const searchRoot = document.getElementById('search');
   if (!searchRoot) return [];
 
@@ -52,8 +54,11 @@ export function getGoogleSearchResultsWithH3(tabType: 'all' | 'image') {
   return [...new Set(h3Elements.map((h3) => getAncestor(h3, levels)))];
 }
 
+/**
+ * Return value should have at least one element, but it may fall back to an empty array if none are found
+ */
 export const getGoogleSearchResults = (
-  tabType: 'all' | 'image'
+  tabType: 'all' | 'image' | 'videos' | 'shopping' | 'news'
 ): HTMLElement[] => {
   const resultsDivG = getGoogleSearchResultsWithDivG();
   if (resultsDivG.length > 0) {
@@ -79,19 +84,16 @@ export function determineThemeFromRgb(
 
 export function getGoogleSearchTabType(
   location: Location
-): 'all' | 'image' | 'videos' | 'shopping' | 'news' | 'map' | null {
+): 'all' | 'image' | 'videos' | 'shopping' | 'news' | null {
   const searchParams = new URLSearchParams(location.search);
   const udm = searchParams.get('udm');
   const tbm = searchParams.get('tbm');
-  const isMaps = location.hostname.includes('maps.google.');
-  if (isMaps || location.pathname.startsWith('/maps')) {
-    return 'map';
+  // Not supporting maps.google. or /maps because there is nothing much to navigate there
+  if (udm === null && tbm === null) {
+    return null;
   }
   switch (tbm) {
-    case undefined:
-    case null:
-      return 'all';
-    case 'isch':
+    case 'isch': // Imase SearCH
       return 'image';
     case 'vid':
       return 'videos';
@@ -99,9 +101,31 @@ export function getGoogleSearchTabType(
       return 'shopping';
     case 'nws':
       return 'news';
-    default:
-      return null;
   }
+  switch (udm) {
+    // https://medium.com/@tanyongsheng0805/every-google-udm-in-the-world-6ee9741434c9
+    // #2: Images
+    // #6: Learn
+    // #7: Videos
+    // #12: News
+    // #14: Web
+    // #15: Attractions
+    // #18: Forums
+    // #28: Shopping
+    // #36: Books
+    // #37: Products
+    // #44: Visual matches
+    // #48: Exact matches
+    case '2':
+      return 'image';
+    case '7':
+      return 'videos';
+    case '12':
+      return 'news';
+    case '28':
+      return 'shopping';
+  }
+  return null; // not expected to be here
 }
 
 export const makeHighlight =

--- a/src/ui-handler.ts
+++ b/src/ui-handler.ts
@@ -79,14 +79,26 @@ export function determineThemeFromRgb(
 
 export function getGoogleSearchTabType(
   location: Location
-): 'all' | 'image' | null {
+): 'all' | 'image' | 'videos' | 'shopping' | 'news' | 'map' | null {
   const searchParams = new URLSearchParams(location.search);
   const udm = searchParams.get('udm');
-  switch (udm) {
+  const tbm = searchParams.get('tbm');
+  const isMaps = location.hostname.includes('maps.google.');
+  if (isMaps || location.pathname.startsWith('/maps')) {
+    return 'map';
+  }
+  switch (tbm) {
+    case undefined:
     case null:
       return 'all';
-    case '2':
+    case 'isch':
       return 'image';
+    case 'vid':
+      return 'videos';
+    case 'shop':
+      return 'shopping';
+    case 'nws':
+      return 'news';
     default:
       return null;
   }


### PR DESCRIPTION
- Added keyboard shortcuts for switching to Videos (v), Shopping (s), News (n), and Map (m) tabs on Google Search.
- Updated the popup UI to allow customization of these shortcuts.
- Enhanced tab detection logic to support all new tab types.
- Users can now switch between all supported tabs, including returning from the Map tab.
- Closes #30.