### PR TITLE
fix: recognize udm Web tab and stop throwing on unknown search tab types (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ### Fixed
 
+- Fix tab type detection on search URLs with `udm=1` (Web tab); recognize `udm` Web variants and fall back to the default tab type instead of throwing on unknown `tbm`/`udm` values (#90)
 - Fix arrow key navigation not called when modifier keys are pressed (#87)
 
 ## [1.9.3] - 2025-08-12

--- a/__tests__/google-navigation.test.ts
+++ b/__tests__/google-navigation.test.ts
@@ -46,16 +46,32 @@ describe('getGoogleSearchTabType', () => {
     expect(getGoogleSearchTabType(urlSearchParams)).toBe('shopping');
   });
 
-  it('should return null for unsupported UDM values', () => {
-    const urlSearchParams = new URLSearchParams('q=dummy+search+query&udm=99');
-    expect(getGoogleSearchTabType(urlSearchParams)).toBeNull();
+  it('should return "all" for the Web tab (udm=1)', () => {
+    const urlSearchParams = new URLSearchParams('q=dummy+search+query&udm=1');
+    expect(getGoogleSearchTabType(urlSearchParams)).toBe('all');
   });
 
-  it('should return null for unsupported TBM values', () => {
+  it('should return "all" for the Web tab alternate variant (udm=14)', () => {
+    const urlSearchParams = new URLSearchParams('q=dummy+search+query&udm=14');
+    expect(getGoogleSearchTabType(urlSearchParams)).toBe('all');
+  });
+
+  it('should fall back to "all" (with a warning) for unsupported UDM values', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const urlSearchParams = new URLSearchParams('q=dummy+search+query&udm=99');
+    expect(getGoogleSearchTabType(urlSearchParams)).toBe('all');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should fall back to "all" (with a warning) for unsupported TBM values', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const urlSearchParams = new URLSearchParams(
       'q=dummy+search+query&tbm=unknown'
     );
-    expect(getGoogleSearchTabType(urlSearchParams)).toBeNull();
+    expect(getGoogleSearchTabType(urlSearchParams)).toBe('all');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('should prioritize TBM over UDM when both are present', () => {
@@ -83,8 +99,11 @@ describe('getGoogleSearchTabType', () => {
   });
 
   it('should handle case sensitivity correctly', () => {
-    // TBM values should be case-sensitive
+    // TBM values are case-sensitive, so an upper-cased value is unrecognized
+    // and falls back to the default "all" tab type.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const urlSearchParams = new URLSearchParams('q=test&tbm=ISCH');
-    expect(getGoogleSearchTabType(urlSearchParams)).toBeNull();
+    expect(getGoogleSearchTabType(urlSearchParams)).toBe('all');
+    warnSpy.mockRestore();
   });
 });

--- a/src/services/search-result-navigation.ts
+++ b/src/services/search-result-navigation.ts
@@ -26,11 +26,12 @@ export function getGoogleSearchTabType(
   }
   switch (udm) {
     // https://medium.com/@tanyongsheng0805/every-google-udm-in-the-world-6ee9741434c9
+    // #1: Web
     // #2: Images
     // #6: Learn
     // #7: Videos
     // #12: News
-    // #14: Web
+    // #14: Web (alternate variant)
     // #15: Attractions
     // #18: Forums
     // #28: Shopping
@@ -38,6 +39,9 @@ export function getGoogleSearchTabType(
     // #37: Products
     // #44: Visual matches
     // #48: Exact matches
+    case '1':
+    case '14':
+      return 'all';
     case '2':
       return 'image';
     case '7':
@@ -47,7 +51,12 @@ export function getGoogleSearchTabType(
     case '28':
       return 'shopping';
   }
-  return null; // not expected to be here
+  // Google periodically introduces new tbm/udm values. Rather than breaking
+  // every shortcut on an unrecognized value, fall back to the default tab type.
+  console.warn(
+    `Unknown Google search tab type (tbm=${tbm}, udm=${udm}); falling back to "all".`
+  );
+  return 'all';
 }
 
 export const makeGetPageType =
@@ -64,7 +73,7 @@ export const makeGetPageType =
       const tabType = getGoogleSearchTabType(searchParam);
       if (!tabType) {
         throw new Error(
-          "Can't to determine search tab type for: " + location.href
+          "Can't determine search tab type for: " + location.href
         );
       }
       return tabType;


### PR DESCRIPTION
## Summary

Fixes #90. On Google search result pages where the URL contains `udm=1` (the **Web** filter), tab-type detection failed: `getGoogleSearchTabType` returned `null`, and `makeGetPageType` threw an uncaught promise rejection, effectively disabling all shortcuts on that tab.

## Changes

- **Recognize `udm` Web variants** — map `udm=1` and `udm=14` to the default `all` tab type (the Web tab shows the same navigable web results).
- **Don't throw on unknown values** — fall back to `all` and emit `console.warn` for any unrecognized `tbm`/`udm` value, so a single unknown value (Google changes these periodically) no longer breaks the whole shortcut path.
- **Typo fix** — `Can't to determine` → `Can't determine`.
- Updated `__tests__/google-navigation.test.ts` to cover the Web tab and the new fallback behavior.

## Testing

- `npx jest` — 66 passed
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)