### PR TITLE
test: add Playwright E2E infrastructure for extension testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ coverage/
 # Lock files from other package managers
 bun.lock*
 yarn.lock
+
+# Playwright
+test-results/
+playwright-report/

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,31 @@
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import { fileURLToPath } from 'url';
+
+const extensionPath = fileURLToPath(new URL('../dist', import.meta.url));
+
+/**
+ * Test fixtures that launch Chromium with the built extension loaded.
+ * Extensions require a persistent context; `channel: 'chromium'` selects the
+ * full browser whose new headless mode supports extensions.
+ */
+export const test = base.extend<{ context: BrowserContext }>({
+  // eslint-disable-next-line no-empty-pattern
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      headless: true,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+    await use(context);
+    await context.close();
+  },
+  page: async ({ context }, use) => {
+    const page = await context.newPage();
+    await use(page);
+  },
+});
+
+export const expect = test.expect;

--- a/e2e/google-navigation.spec.ts
+++ b/e2e/google-navigation.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from './fixtures';
+import { HIGHLIGHT_SELECTOR, serveFixtures } from './helpers';
+
+const GOOGLE_ALL_URL = 'https://www.google.com/search?q=github+closes+comment+pr';
+
+test.beforeEach(async ({ context }) => {
+  await serveFixtures(context, {
+    'https://www.google.com/search': '20250529_all_tokyo_10.html',
+  });
+});
+
+test('highlights the first result on load', async ({ page }) => {
+  await page.goto(GOOGLE_ALL_URL);
+  const highlighted = page.locator(HIGHLIGHT_SELECTOR);
+  await expect(highlighted).toHaveCount(1);
+  const firstHeading = page.locator('#rso h3, #search h3').first();
+  await expect(highlighted.locator('h3').first()).toHaveText(
+    (await firstHeading.textContent()) ?? ''
+  );
+});
+
+test('moves the highlight down with j and back up with k', async ({
+  page,
+}) => {
+  await page.goto(GOOGLE_ALL_URL);
+  const highlighted = page.locator(HIGHLIGHT_SELECTOR);
+  await expect(highlighted).toHaveCount(1);
+  const headingOfHighlighted = () =>
+    highlighted.locator('h3').first().textContent();
+
+  const first = await headingOfHighlighted();
+  await page.keyboard.press('j');
+  await expect(highlighted).toHaveCount(1);
+  const second = await headingOfHighlighted();
+  expect(second).not.toBe(first);
+
+  await page.keyboard.press('k');
+  await expect(highlighted).toHaveCount(1);
+  expect(await headingOfHighlighted()).toBe(first);
+});
+
+test('opens the highlighted result with Enter', async ({ page }) => {
+  await page.goto(GOOGLE_ALL_URL);
+  const highlighted = page.locator(HIGHLIGHT_SELECTOR);
+  await expect(highlighted).toHaveCount(1);
+  const href = await highlighted.locator('a[href]').first().getAttribute('href');
+  expect(href).toMatch(/^https?:\/\//);
+
+  await page.keyboard.press('Enter');
+  await page.waitForURL(href!);
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,52 @@
+import type { BrowserContext } from '@playwright/test';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const fixturesDir = fileURLToPath(
+  new URL('../__tests__/htmls', import.meta.url)
+);
+
+/** Selector matching the extension's highlighted result in either theme. */
+export const HIGHLIGHT_SELECTOR = '.sn-selected-light, .sn-selected-dark';
+
+/**
+ * Strip <script> tags from a saved page so the page's own bundled JavaScript
+ * does not run against the snapshot; the extension's content script is
+ * injected separately by the browser and is unaffected.
+ */
+const stripScripts = (html: string): string =>
+  html.replace(/<script\b[\s\S]*?<\/script>/gi, '');
+
+/**
+ * Serve saved-page fixtures for matching document URLs and block all other
+ * requests, so tests are deterministic and never hit the network.
+ * Non-matching document navigations receive a small placeholder page, which
+ * lets tests assert on navigation targets (e.g. after pressing Enter).
+ */
+export const serveFixtures = async (
+  context: BrowserContext,
+  fixtureByUrlPrefix: Record<string, string>
+): Promise<void> => {
+  await context.route('**/*', async (route) => {
+    const request = route.request();
+    if (request.resourceType() !== 'document') {
+      return route.abort();
+    }
+    const url = request.url();
+    const entry = Object.entries(fixtureByUrlPrefix).find(([prefix]) =>
+      url.startsWith(prefix)
+    );
+    if (!entry) {
+      return route.fulfill({
+        contentType: 'text/html; charset=utf-8',
+        body: '<!doctype html><title>placeholder</title>',
+      });
+    }
+    const html = await fs.readFile(path.join(fixturesDir, entry[1]), 'utf8');
+    return route.fulfill({
+      contentType: 'text/html; charset=utf-8',
+      body: stripScripts(html),
+    });
+  });
+};

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -11,12 +11,16 @@ const fixturesDir = fileURLToPath(
 export const HIGHLIGHT_SELECTOR = '.sn-selected-light, .sn-selected-dark';
 
 /**
- * Strip <script> tags from a saved page so the page's own bundled JavaScript
- * does not run against the snapshot; the extension's content script is
- * injected separately by the browser and is unaffected.
+ * Prepare a saved page for serving: strip <script> tags so the page's own
+ * bundled JavaScript does not run against the snapshot (the extension's
+ * content script is injected separately by the browser and is unaffected),
+ * and drop highlight classes the extension may have baked into the snapshot
+ * when the page was saved.
  */
-const stripScripts = (html: string): string =>
-  html.replace(/<script\b[\s\S]*?<\/script>/gi, '');
+const sanitizeSnapshot = (html: string): string =>
+  html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, '')
+    .replace(/\bsn-selected-(?:dark|light)\b/g, '');
 
 /**
  * Serve saved-page fixtures for matching document URLs and block all other
@@ -46,7 +50,7 @@ export const serveFixtures = async (
     const html = await fs.readFile(path.join(fixturesDir, entry[1]), 'utf8');
     return route.fulfill({
       contentType: 'text/html; charset=utf-8',
-      body: stripScripts(html),
+      body: sanitizeSnapshot(html),
     });
   });
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,8 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFiles: ['<rootDir>/jest.setup.js'],
+  // Playwright owns e2e/; keep Jest to the unit tests in __tests__/
+  testMatch: ['<rootDir>/__tests__/**/*.test.ts'],
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "build:prod": "ENV=prod rollup -c",
     "format": "prettier --write \"src/**/*.{js,ts,tsx,json,css,scss,md}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts,tsx,json,css,scss,md}\"",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "pnpm run build:dev && playwright test"
   },
   "author": "Naoki Watanave",
   "license": "MIT",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/chrome": "^0.0.315",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  // Each test launches its own persistent browser context with the extension
+  // loaded, so keep them sequential to stay light on resources.
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@3.29.5)
@@ -483,6 +486,11 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/plugin-terser@0.4.4':
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
     engines: {node: '>=14.0.0'}
@@ -904,6 +912,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1416,6 +1429,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -2319,6 +2342,10 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rollup/plugin-terser@0.4.4(rollup@3.29.5)':
     dependencies:
       serialize-javascript: 6.0.2
@@ -2760,6 +2787,9 @@ snapshots:
       universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3443,6 +3473,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 


### PR DESCRIPTION
## Summary
- Launch Chromium with the built extension loaded (persistent context, new headless via `channel: 'chromium'`).
- Serve the saved Google/YouTube page snapshots from `__tests__/htmls` via route interception, blocking all other network requests, so E2E runs are deterministic and never hit the live sites.
- Snapshot sanitizing: strips the pages' own `<script>` tags and any `sn-selected-*` highlight classes that were baked in when a snapshot was saved with the extension active.
- Baseline spec: j/k navigation and Enter on the Google All tab.
- Scopes Jest to `__tests__/` so it ignores Playwright specs.

## Usage
```
npx playwright install chromium   # once
pnpm test:e2e                     # builds dist and runs Playwright
```

## Stacked PRs
This is the base of a stack; merge in this order:
1. this PR
2. #76 fix (infinite scroll)
3. #73 fix (YouTube stability)
4. #72 feature (image Enter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)