### PR TITLE
fix: stabilize YouTube search result navigation

### DIFF
--- a/e2e/youtube-navigation.spec.ts
+++ b/e2e/youtube-navigation.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from './fixtures';
+import { HIGHLIGHT_SELECTOR, serveFixtures } from './helpers';
+
+const YOUTUBE_RESULTS_URL =
+  'https://www.youtube.com/results?search_query=prokofiev+piano+concerto+3';
+
+const titleOfHighlighted = async (page: {
+  locator: (selector: string) => {
+    first: () => {
+      evaluate: <R>(fn: (el: Element) => R) => Promise<R>;
+    };
+  };
+}) =>
+  page
+    .locator(HIGHLIGHT_SELECTOR)
+    .first()
+    .evaluate(
+      (el) =>
+        el.querySelector('#video-title')?.textContent?.trim() ??
+        el.textContent?.trim().slice(0, 80) ??
+        ''
+    );
+
+test.beforeEach(async ({ context }) => {
+  await serveFixtures(context, {
+    'https://www.youtube.com/results':
+      '20250620-youtube-search-result-prokofiev-piano-concerto-3-tokyo.html',
+  });
+});
+
+test('navigates YouTube results with j and k', async ({ page }) => {
+  await page.goto(YOUTUBE_RESULTS_URL);
+  const highlighted = page.locator(HIGHLIGHT_SELECTOR);
+  await expect(highlighted).toHaveCount(1);
+
+  const first = await titleOfHighlighted(page);
+  await page.keyboard.press('j');
+  await expect(highlighted).toHaveCount(1);
+  const second = await titleOfHighlighted(page);
+  expect(second).not.toBe(first);
+
+  await page.keyboard.press('k');
+  await expect(highlighted).toHaveCount(1);
+  expect(await titleOfHighlighted(page)).toBe(first);
+});
+
+test('keeps exactly one active listener across SPA navigations', async ({
+  page,
+}) => {
+  await page.goto(YOUTUBE_RESULTS_URL);
+  const highlighted = page.locator(HIGHLIGHT_SELECTOR);
+  await expect(highlighted).toHaveCount(1);
+
+  const first = await titleOfHighlighted(page);
+  await page.keyboard.press('j');
+  const second = await titleOfHighlighted(page);
+  expect(second).not.toBe(first);
+
+  // Simulate YouTube SPA navigation, which re-runs the extension's init().
+  await page.evaluate(() =>
+    document.dispatchEvent(new Event('yt-navigate-finish'))
+  );
+  // Re-init highlights the first result again.
+  await expect(
+    page.locator(HIGHLIGHT_SELECTOR).filter({ hasText: first })
+  ).toHaveCount(1);
+
+  // One keypress must move the highlight exactly one step; with stale
+  // listeners piling up (issue #73) it would move several results at once
+  // and leave multiple highlights behind.
+  await page.keyboard.press('j');
+  await expect(highlighted).toHaveCount(1);
+  expect(await titleOfHighlighted(page)).toBe(second);
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -18,10 +18,24 @@ import './style.scss';
 
 (async () => {
   const keymapManager = await keymapManagerPromise;
+  // init() re-runs on SPA navigation (yt-navigate-finish, popstate). Abort the
+  // previous keydown listener so each keypress is handled exactly once (issue #73).
+  let keydownAbortController: AbortController | null = null;
 
   async function init() {
+    keydownAbortController?.abort();
+    keydownAbortController = new AbortController();
+    const { signal } = keydownAbortController;
+
     let currentIndex: number = 0;
-    const pageType = getPageType(window.location);
+    let pageType: PageType;
+    try {
+      pageType = getPageType(window.location);
+    } catch {
+      // Not a supported search page (e.g. YouTube /watch reached via SPA
+      // navigation). Stay inert until the next navigation.
+      return;
+    }
     // ON YouTube search, you need wait for client rendering. Search root is
     // shown with 8-10 search results, which is enough to cover a viewport.
     // More results are streamed very quickly. Those results are not taken at this moment,
@@ -38,257 +52,282 @@ import './style.scss';
     }
     const theme = detectTheme(window, document, pageType);
 
-    highlight(results, currentIndex, theme, {
-      scrollIntoView: false,
-    });
+    // Results may not be rendered yet (YouTube streams them in). Pressing
+    // move_down re-queries, so navigation recovers once they appear.
+    if (results.length > 0) {
+      highlight(results, currentIndex, theme, {
+        scrollIntoView: false,
+      });
 
-    // Simulate YouTube hover for YouTube search results
-    if (pageType === 'youtube-search-result') {
-      simulateYouTubeHover(results[currentIndex], 'mouseenter');
+      // Simulate YouTube hover for YouTube search results
+      if (pageType === 'youtube-search-result') {
+        simulateYouTubeHover(results[currentIndex], 'mouseenter');
+      }
     }
 
     // Add keydown event listener for all Google Search pages
-    document.addEventListener('keydown', (e: KeyboardEvent) => {
-      if (
-        ['INPUT', 'TEXTAREA'].includes(
-          (document.activeElement && document.activeElement.tagName) || ''
-        )
-      ) {
-        return;
-      }
-
-      if (
-        keymapManager.isKeyMatch(e, 'move_down') ||
-        keymapManager.isKeyMatch(e, 'arrow_move_down')
-      ) {
-        // down
-        e.preventDefault();
-        const dynamicLoadPageTypes: PageType[] = [
-          'all',
-          'image',
-          'youtube-search-result',
-        ] as const;
+    document.addEventListener(
+      'keydown',
+      (e: KeyboardEvent) => {
         if (
-          currentIndex === results.length - 1 &&
-          dynamicLoadPageTypes.includes(pageType)
-        ) {
-          results = getSearchResults(document, pageType);
-        }
-        if (results.length > 0 && currentIndex < results.length - 1) {
-          // Simulate YouTube hover leave for the current element before moving
-          if (pageType === 'youtube-search-result') {
-            simulateYouTubeHover(results[currentIndex], 'mouseleave');
-          }
-          unhighlight(results, currentIndex);
-          currentIndex++;
-          highlight(results, currentIndex, theme, {
-            scrollIntoView: true,
-          });
-          // Don't simulate hover for move down to avoid triggering preview
-        }
-      } else if (
-        keymapManager.isKeyMatch(e, 'move_up') ||
-        keymapManager.isKeyMatch(e, 'arrow_move_up')
-      ) {
-        // up
-        e.preventDefault();
-        if (results.length > 0 && currentIndex > 0) {
-          // Simulate YouTube hover leave for the current element before moving
-          if (pageType === 'youtube-search-result') {
-            simulateYouTubeHover(results[currentIndex], 'mouseleave');
-          }
-          unhighlight(results, currentIndex);
-          currentIndex--;
-          highlight(results, currentIndex, theme, {
-            scrollIntoView: true,
-          });
-          // Simulate YouTube hover for the new element
-          if (pageType === 'youtube-search-result') {
-            simulateYouTubeHover(results[currentIndex], 'mouseenter');
-          }
-        }
-      } else if (keymapManager.isKeyMatch(e, 'open_link')) {
-        // open link or expand section
-        e.preventDefault();
-        if (
-          !(
-            0 < results.length &&
-            0 <= currentIndex &&
-            currentIndex < results.length
+          ['INPUT', 'TEXTAREA'].includes(
+            (document.activeElement && document.activeElement.tagName) || ''
           )
         ) {
-          return; // not expected to happen
+          return;
         }
 
-        // Check if this is a "People also ask" section first
-        const currentResult = results[currentIndex];
-        const hasRelatedQuestionPair = currentResult.querySelector(
-          '.related-question-pair'
-        );
-
-        // This is a "People also ask" section, toggle expansion
-        // ToDo: `open_link` (Mostly Enter key) should open a link in an expanded accordion, instead of closing it.
-        if (hasRelatedQuestionPair) {
-          togglePeopleAlsoAskAccordion(currentResult);
-
-          setTimeout(() => {
-            const newResults = getSearchResults(document, pageType);
-            if (newResults.length > 0) {
-              results = newResults;
-              // Ensure currentIndex is still valid after recalculation
-              if (currentIndex >= results.length) {
-                currentIndex = results.length - 1;
-              }
-              // Re-highlight the current element in case DOM structure changed
-              // Note: Don't unhighlight first as it would collapse the expanded section
-              highlight(results, currentIndex, theme, {
-                scrollIntoView: false,
-              });
-              // Simulate YouTube hover for the re-highlighted element
+        if (
+          keymapManager.isKeyMatch(e, 'move_down') ||
+          keymapManager.isKeyMatch(e, 'arrow_move_down')
+        ) {
+          // down
+          e.preventDefault();
+          const dynamicLoadPageTypes: PageType[] = [
+            'all',
+            'image',
+            'youtube-search-result',
+          ] as const;
+          if (
+            currentIndex >= results.length - 1 &&
+            dynamicLoadPageTypes.includes(pageType)
+          ) {
+            const hadNoResults = results.length === 0;
+            results = getSearchResults(document, pageType);
+            if (hadNoResults && results.length > 0) {
+              // Results appeared after an empty initial load; highlight the
+              // first one instead of moving past it.
+              currentIndex = 0;
+              highlight(results, currentIndex, theme, { scrollIntoView: true });
               if (pageType === 'youtube-search-result') {
                 simulateYouTubeHover(results[currentIndex], 'mouseenter');
               }
+              return;
             }
-          }, PEOPLE_ALSO_ASK_ACCORDION_TIMEOUT);
-          return;
-        }
+          }
+          if (results.length > 0 && currentIndex < results.length - 1) {
+            // Simulate YouTube hover leave for the current element before moving
+            if (pageType === 'youtube-search-result') {
+              simulateYouTubeHover(results[currentIndex], 'mouseleave');
+            }
+            unhighlight(results, currentIndex);
+            currentIndex++;
+            highlight(results, currentIndex, theme, {
+              scrollIntoView: true,
+            });
+            // Don't simulate hover for move down to avoid triggering preview
+          }
+        } else if (
+          keymapManager.isKeyMatch(e, 'move_up') ||
+          keymapManager.isKeyMatch(e, 'arrow_move_up')
+        ) {
+          // up
+          e.preventDefault();
+          if (results.length > 0 && currentIndex > 0) {
+            // Simulate YouTube hover leave for the current element before moving
+            if (pageType === 'youtube-search-result') {
+              simulateYouTubeHover(results[currentIndex], 'mouseleave');
+            }
+            unhighlight(results, currentIndex);
+            currentIndex--;
+            highlight(results, currentIndex, theme, {
+              scrollIntoView: true,
+            });
+            // Simulate YouTube hover for the new element
+            if (pageType === 'youtube-search-result') {
+              simulateYouTubeHover(results[currentIndex], 'mouseenter');
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'open_link')) {
+          // open link or expand section
+          e.preventDefault();
+          if (
+            !(
+              0 < results.length &&
+              0 <= currentIndex &&
+              currentIndex < results.length
+            )
+          ) {
+            return; // not expected to happen
+          }
 
-        // Otherwise, handle as regular link opening
-        const link = results[currentIndex].querySelector(
-          'a[href]'
-        ) as HTMLAnchorElement;
-        if (!link?.href) return;
-        const { ctrlKey, metaKey, shiftKey } = e;
-        if (ctrlKey || metaKey) {
-          // Ctrl+Click or Cmd+Click → new tab
-          window.open(link.href, '_blank');
-        } else if (shiftKey) {
-          // Shift+Click → new window (popup)
-          // any non-undefined "features" string forces a new window
-          window.open(link.href, '_blank', '');
-        } else {
-          // plain Enter/Click → same tab
-          link.click(); // for accessibility
-        }
-      } else if (
-        keymapManager.isKeyMatch(e, 'navigate_previous') ||
-        keymapManager.isKeyMatch(e, 'arrow_navigate_previous')
-      ) {
-        // previous page
-        e.preventDefault();
-        // TODO: add support for image search
-        if (e.ctrlKey || e.metaKey) {
-          return;
-        }
-        if (['all', 'videos', 'shopping', 'news'].includes(pageType)) {
-          const prevLink = document.querySelector('#pnprev');
-          if (prevLink instanceof HTMLAnchorElement && prevLink.href) {
-            window.location.href = prevLink.href;
-          }
-        }
-      } else if (
-        keymapManager.isKeyMatch(e, 'navigate_next') ||
-        keymapManager.isKeyMatch(e, 'arrow_navigate_next')
-      ) {
-        // next page
-        e.preventDefault();
-        if (['all', 'videos', 'shopping', 'news'].includes(pageType)) {
-          const nextLink = document.querySelector('#pnnext');
-          if (nextLink instanceof HTMLAnchorElement && nextLink.href) {
-            window.location.href = nextLink.href;
-          }
-        }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_image_search')) {
-        // switch to image search
-        e.preventDefault();
-        if (e.ctrlKey || e.metaKey) {
-          return;
-        }
-        if (pageType !== 'image') {
-          const searchParams = new URLSearchParams(window.location.search);
-          const query = searchParams.get('q');
+          // Check if this is a "People also ask" section first
+          const currentResult = results[currentIndex];
+          const hasRelatedQuestionPair = currentResult.querySelector(
+            '.related-question-pair'
+          );
 
-          if (query) {
-            // Construct image search URL
-            const imageSearchUrl = `https://www.google.com/search?tbm=isch&q=${encodeURIComponent(query)}`;
-            window.location.href = imageSearchUrl;
+          // This is a "People also ask" section, toggle expansion
+          // ToDo: `open_link` (Mostly Enter key) should open a link in an expanded accordion, instead of closing it.
+          if (hasRelatedQuestionPair) {
+            togglePeopleAlsoAskAccordion(currentResult);
+
+            setTimeout(() => {
+              const newResults = getSearchResults(document, pageType);
+              if (newResults.length > 0) {
+                results = newResults;
+                // Ensure currentIndex is still valid after recalculation
+                if (currentIndex >= results.length) {
+                  currentIndex = results.length - 1;
+                }
+                // Re-highlight the current element in case DOM structure changed
+                // Note: Don't unhighlight first as it would collapse the expanded section
+                highlight(results, currentIndex, theme, {
+                  scrollIntoView: false,
+                });
+                // Simulate YouTube hover for the re-highlighted element
+                if (pageType === 'youtube-search-result') {
+                  simulateYouTubeHover(results[currentIndex], 'mouseenter');
+                }
+              }
+            }, PEOPLE_ALSO_ASK_ACCORDION_TIMEOUT);
+            return;
           }
-        }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_all_search')) {
-        // switch to all search
-        e.preventDefault();
-        if (pageType !== 'all') {
-          const searchParams = new URLSearchParams(window.location.search);
-          const query = searchParams.get('q');
-          if (!query) {
-            window.location.href = 'https://www.google.com';
+
+          // Otherwise, handle as regular link opening
+          const link = results[currentIndex].querySelector(
+            'a[href]'
+          ) as HTMLAnchorElement;
+          if (!link?.href) return;
+          const { ctrlKey, metaKey, shiftKey } = e;
+          if (ctrlKey || metaKey) {
+            // Ctrl+Click or Cmd+Click → new tab
+            window.open(link.href, '_blank');
+          } else if (shiftKey) {
+            // Shift+Click → new window (popup)
+            // any non-undefined "features" string forces a new window
+            window.open(link.href, '_blank', '');
           } else {
-            const allSearchUrl = `https://www.google.com/search?q=${encodeURIComponent(query)}`;
-            window.location.href = allSearchUrl;
+            // plain Enter/Click → same tab
+            link.click(); // for accessibility
           }
-        }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_videos')) {
-        // switch to videos tab
-        e.preventDefault();
-        if (pageType !== 'videos') {
+        } else if (
+          keymapManager.isKeyMatch(e, 'navigate_previous') ||
+          keymapManager.isKeyMatch(e, 'arrow_navigate_previous')
+        ) {
+          // previous page
+          e.preventDefault();
+          // TODO: add support for image search
+          if (e.ctrlKey || e.metaKey) {
+            return;
+          }
+          if (['all', 'videos', 'shopping', 'news'].includes(pageType)) {
+            const prevLink = document.querySelector('#pnprev');
+            if (prevLink instanceof HTMLAnchorElement && prevLink.href) {
+              window.location.href = prevLink.href;
+            }
+          }
+        } else if (
+          keymapManager.isKeyMatch(e, 'navigate_next') ||
+          keymapManager.isKeyMatch(e, 'arrow_navigate_next')
+        ) {
+          // next page
+          e.preventDefault();
+          if (['all', 'videos', 'shopping', 'news'].includes(pageType)) {
+            const nextLink = document.querySelector('#pnnext');
+            if (nextLink instanceof HTMLAnchorElement && nextLink.href) {
+              window.location.href = nextLink.href;
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_image_search')) {
+          // switch to image search
+          e.preventDefault();
+          if (e.ctrlKey || e.metaKey) {
+            return;
+          }
+          if (pageType !== 'image') {
+            const searchParams = new URLSearchParams(window.location.search);
+            const query = searchParams.get('q');
+
+            if (query) {
+              // Construct image search URL
+              const imageSearchUrl = `https://www.google.com/search?tbm=isch&q=${encodeURIComponent(query)}`;
+              window.location.href = imageSearchUrl;
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_all_search')) {
+          // switch to all search
+          e.preventDefault();
+          if (pageType !== 'all') {
+            const searchParams = new URLSearchParams(window.location.search);
+            const query = searchParams.get('q');
+            if (!query) {
+              window.location.href = 'https://www.google.com';
+            } else {
+              const allSearchUrl = `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+              window.location.href = allSearchUrl;
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_videos')) {
+          // switch to videos tab
+          e.preventDefault();
+          if (pageType !== 'videos') {
+            const searchParams = new URLSearchParams(window.location.search);
+            const query = searchParams.get('q');
+            if (query) {
+              const videosUrl = `https://www.google.com/search?tbm=vid&q=${encodeURIComponent(query)}`;
+              window.location.href = videosUrl;
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_shopping')) {
+          // switch to shopping tab
+          e.preventDefault();
+          if (pageType !== 'shopping') {
+            const searchParams = new URLSearchParams(window.location.search);
+            const query = searchParams.get('q');
+            if (query) {
+              const shoppingUrl = `https://www.google.com/search?tbm=shop&q=${encodeURIComponent(query)}`;
+              window.location.href = shoppingUrl;
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_news')) {
+          // switch to news tab
+          e.preventDefault();
+          if (pageType !== 'news') {
+            const searchParams = new URLSearchParams(window.location.search);
+            const query = searchParams.get('q');
+            if (query) {
+              const newsUrl = `https://www.google.com/search?tbm=nws&q=${encodeURIComponent(query)}`;
+              window.location.href = newsUrl;
+            }
+          }
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_map')) {
+          // switch to map tab
+          e.preventDefault();
           const searchParams = new URLSearchParams(window.location.search);
           const query = searchParams.get('q');
           if (query) {
-            const videosUrl = `https://www.google.com/search?tbm=vid&q=${encodeURIComponent(query)}`;
-            window.location.href = videosUrl;
+            const mapUrl = `https://www.google.com/maps/search/${encodeURIComponent(query)}`;
+            window.location.href = mapUrl;
           }
-        }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_shopping')) {
-        // switch to shopping tab
-        e.preventDefault();
-        if (pageType !== 'shopping') {
+        } else if (keymapManager.isKeyMatch(e, 'switch_to_youtube')) {
+          // switch to YouTube
+          e.preventDefault();
           const searchParams = new URLSearchParams(window.location.search);
           const query = searchParams.get('q');
           if (query) {
-            const shoppingUrl = `https://www.google.com/search?tbm=shop&q=${encodeURIComponent(query)}`;
-            window.location.href = shoppingUrl;
+            const youtubeUrl = `https://www.youtube.com/results?search_query=${encodeURIComponent(query)}`;
+            window.location.href = youtubeUrl;
           }
         }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_news')) {
-        // switch to news tab
-        e.preventDefault();
-        if (pageType !== 'news') {
-          const searchParams = new URLSearchParams(window.location.search);
-          const query = searchParams.get('q');
-          if (query) {
-            const newsUrl = `https://www.google.com/search?tbm=nws&q=${encodeURIComponent(query)}`;
-            window.location.href = newsUrl;
-          }
-        }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_map')) {
-        // switch to map tab
-        e.preventDefault();
-        const searchParams = new URLSearchParams(window.location.search);
-        const query = searchParams.get('q');
-        if (query) {
-          const mapUrl = `https://www.google.com/maps/search/${encodeURIComponent(query)}`;
-          window.location.href = mapUrl;
-        }
-      } else if (keymapManager.isKeyMatch(e, 'switch_to_youtube')) {
-        // switch to YouTube
-        e.preventDefault();
-        const searchParams = new URLSearchParams(window.location.search);
-        const query = searchParams.get('q');
-        if (query) {
-          const youtubeUrl = `https://www.youtube.com/results?search_query=${encodeURIComponent(query)}`;
-          window.location.href = youtubeUrl;
-        }
-      }
-    });
+      },
+      { signal }
+    );
   }
 
-  init();
+  const safeInit = () => {
+    init().catch((error) => {
+      console.error('search-navigator: failed to initialize', error);
+    });
+  };
+
+  safeInit();
 
   // YouTube navigation event listener
-  document.addEventListener('yt-navigate-finish', init);
+  document.addEventListener('yt-navigate-finish', safeInit);
 
   // popstate (back/forward) event listener
-  window.addEventListener('popstate', init);
+  window.addEventListener('popstate', safeInit);
 
   // Listen for keymap updates from background script
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/src/services/get-search-results.ts
+++ b/src/services/get-search-results.ts
@@ -36,14 +36,16 @@ export type PageType = GoogleSearchTabType | 'youtube-search-result';
 
 export function getSearchRootSelector(pageType: PageType): string {
   if (pageType === 'youtube-search-result') {
-    return '#contents';
+    // Many YouTube elements share id="contents"; scope to the search page
+    // container so we don't match an unrelated node (issue #73).
+    return 'ytd-search #contents';
   }
   return '#rso, #search';
 }
 
 function getSearchRoots(pageType: PageType, doc: Document): HTMLDivElement[] {
   if (pageType === 'youtube-search-result') {
-    return [doc.getElementById('contents')].filter(
+    return [doc.querySelector('ytd-search #contents')].filter(
       (el): el is HTMLDivElement => el !== null
     );
   }
@@ -99,8 +101,11 @@ export const getYouTubeSearchResults = (
 
   const combinedSelector = selectors.join(',');
 
-  // Single DOM query
-  const elements = doc.querySelectorAll(combinedSelector);
+  // Scope the query to the search results container: YouTube keeps DOM of
+  // previously visited pages around, and a document-wide query could pick up
+  // renderers from those hidden pages (issue #73).
+  const root = doc.querySelector('ytd-search #contents') ?? doc;
+  const elements = root.querySelectorAll(combinedSelector);
   return Array.from(elements) as HTMLDivElement[];
 };
 


### PR DESCRIPTION
Fixes #73

## Root causes found
1. **Stale keydown listeners piled up**: `init()` re-runs on every `yt-navigate-finish`/`popstate`, and each run added another document-level keydown listener with its own `results`/`currentIndex` closure. After a few SPA navigations one keypress was handled by several listeners, each moving its own highlight.
2. **Ambiguous search root**: the root was located with `getElementById('contents')`, but a YouTube results page has ~12 elements with `id="contents"` — which one comes first depends on page state.
3. **Init crash on slow rendering**: when the root appeared before any results streamed in, `highlight()` threw on the empty array, killing `init()` before the keydown listener was attached — navigation stayed dead until reload.
4. `getPageType` threw on unsupported pages (e.g. `/watch` reached via SPA navigation), leaving unhandled rejections and stale listeners active.

## Changes
- Abort the previous keydown listener (AbortController) whenever `init()` re-runs.
- Scope the YouTube root and result queries to `ytd-search #contents`.
- Tolerate an empty result list at init; pressing move-down re-queries and highlights the first result once available.
- Stay inert on unsupported pages instead of throwing.

## Tests
- E2E (Playwright): j/k navigation on a YouTube results snapshot, plus a regression test that dispatches `yt-navigate-finish` and asserts one keypress moves the highlight exactly one step with a single highlight left. Verified the regression test fails without this fix and passes with it.

## Stack
Based on #93 — merge #92 → #93 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)