### PR TITLE
feat: Enter enlarges image result, Enter again opens source page

### DIFF
--- a/__tests__/google-image-anchors.test.ts
+++ b/__tests__/google-image-anchors.test.ts
@@ -1,0 +1,35 @@
+import { JSDOM } from 'jsdom';
+import path from 'path';
+import {
+  getGoogleImageResultAnchors,
+  getGoogleSearchResults,
+} from '../src/services';
+
+describe('get Google image result anchors', () => {
+  let results: HTMLDivElement[];
+
+  beforeAll(async () => {
+    const htmlPath = path.join(
+      __dirname,
+      '/htmls/20250614-image-château-chalon-tokyo.html'
+    );
+    const dom = await JSDOM.fromFile(htmlPath);
+    results = getGoogleSearchResults('image', dom.window.document);
+  });
+
+  it('finds a thumbnail anchor and an external source anchor on the first result', () => {
+    const { thumbnail, source } = getGoogleImageResultAnchors(results[0]);
+    expect(thumbnail).not.toBeNull();
+    expect(thumbnail?.getAttribute('href') ?? '').toBe('');
+    expect(thumbnail?.querySelector('img')).not.toBeNull();
+    expect(source?.getAttribute('href')).toMatch(/^https:\/\//);
+  });
+
+  it('finds thumbnail and source anchors on every result', () => {
+    const missing = results.filter((result) => {
+      const { thumbnail, source } = getGoogleImageResultAnchors(result);
+      return thumbnail === null || source === null;
+    });
+    expect(missing.length).toBe(0);
+  });
+});

--- a/e2e/image-enter.spec.ts
+++ b/e2e/image-enter.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from './fixtures';
+import { HIGHLIGHT_SELECTOR, serveFixtures } from './helpers';
+
+const GOOGLE_IMAGE_URL =
+  'https://www.google.com/search?tbm=isch&q=ch%C3%A2teau-chalon';
+
+test.beforeEach(async ({ context }) => {
+  await serveFixtures(context, {
+    'https://www.google.com/search': '20250614-image-château-chalon-tokyo.html',
+  });
+});
+
+test('Enter enlarges the image, Enter again opens the source page', async ({
+  page,
+}) => {
+  await page.goto(GOOGLE_IMAGE_URL);
+  const highlighted = page.locator(HIGHLIGHT_SELECTOR);
+  await expect(highlighted).toHaveCount(1);
+
+  // Move to the second result so the test also covers per-result state.
+  await page.keyboard.press('j');
+  await expect(highlighted).toHaveCount(1);
+  const sourceHref = await highlighted
+    .locator('a[href^="http"]')
+    .first()
+    .getAttribute('href');
+  expect(sourceHref).toMatch(/^https?:\/\//);
+
+  // First Enter clicks the thumbnail anchor (opens Google's preview panel
+  // on the live site) and must not leave the results page nor open the
+  // source page in a new tab.
+  let popupsOpened = 0;
+  page.on('popup', () => popupsOpened++);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(300);
+  expect(page.url()).toBe(GOOGLE_IMAGE_URL);
+  expect(popupsOpened).toBe(0);
+
+  // Second Enter on the same result opens the source page; the anchor has
+  // target="_blank", so it opens in a new tab.
+  const [sourcePage] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.keyboard.press('Enter'),
+  ]);
+  await sourcePage.waitForURL(sourceHref!);
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,7 +12,11 @@ import {
   waitForSearchRoot,
 } from './dependency-injection';
 import type { PageType } from './services';
-import { simulateYouTubeHover, togglePeopleAlsoAskAccordion } from './services';
+import {
+  getGoogleImageResultAnchors,
+  simulateYouTubeHover,
+  togglePeopleAlsoAskAccordion,
+} from './services';
 
 import './style.scss';
 
@@ -28,6 +32,9 @@ import './style.scss';
     const { signal } = keydownAbortController;
 
     let currentIndex: number = 0;
+    // Index of the image result whose preview panel was opened with Enter;
+    // pressing Enter again on it opens the source page (issue #72).
+    let enlargedIndex: number | null = null;
     let pageType: PageType;
     try {
       pageType = getPageType(window.location);
@@ -151,8 +158,32 @@ import './style.scss';
             return; // not expected to happen
           }
 
-          // Check if this is a "People also ask" section first
           const currentResult = results[currentIndex];
+
+          if (pageType === 'image') {
+            // First Enter enlarges (opens Google's preview panel); Enter
+            // again — or any modifier — opens the source page (issue #72).
+            const { thumbnail, source } =
+              getGoogleImageResultAnchors(currentResult);
+            const { ctrlKey, metaKey, shiftKey } = e;
+            const hasModifier = ctrlKey || metaKey || shiftKey;
+            if (!hasModifier && enlargedIndex !== currentIndex && thumbnail) {
+              thumbnail.click();
+              enlargedIndex = currentIndex;
+              return;
+            }
+            if (!source?.href) return;
+            if (ctrlKey || metaKey) {
+              window.open(source.href, '_blank');
+            } else if (shiftKey) {
+              window.open(source.href, '_blank', '');
+            } else {
+              source.click();
+            }
+            return;
+          }
+
+          // Check if this is a "People also ask" section first
           const hasRelatedQuestionPair = currentResult.querySelector(
             '.related-question-pair'
           );

--- a/src/services/platform-interactions.ts
+++ b/src/services/platform-interactions.ts
@@ -51,6 +51,29 @@ export const togglePeopleAlsoAskAccordion = (element: HTMLElement): void => {
 };
 
 /**
+ * Split a Google Images grid result into its two anchors: the thumbnail
+ * anchor that opens Google's preview panel when clicked, and the anchor
+ * pointing to the source page.
+ */
+export const getGoogleImageResultAnchors = (
+  result: HTMLElement
+): {
+  thumbnail: HTMLAnchorElement | null;
+  source: HTMLAnchorElement | null;
+} => {
+  const anchors = Array.from(result.querySelectorAll('a'));
+  // The thumbnail anchor has no href until Google populates it with a
+  // site-relative /imgres URL; the source anchor links straight to the
+  // external page.
+  const isExternalHref = (a: HTMLAnchorElement): boolean =>
+    /^https?:\/\//.test(a.getAttribute('href') ?? '');
+  return {
+    thumbnail: anchors.find((a) => !isExternalHref(a)) ?? null,
+    source: anchors.find(isExternalHref) ?? null,
+  };
+};
+
+/**
  * Helper function to simulate YouTube thumbnail hover
  */
 export const simulateYouTubeHover = (


### PR DESCRIPTION
Closes #72

## Behavior
On the Images tab:
- First **Enter** clicks the thumbnail anchor, which opens Google's preview (enlarge) panel.
- **Enter again** on the same result opens the image's source page (the source anchor has `target="_blank"`, so it opens in a new tab, same as clicking it).
- **Ctrl/Cmd/Shift+Enter** opens the source page directly without enlarging first.

## Implementation
Each image grid result has two anchors: the thumbnail anchor (no href until Google populates a site-relative `/imgres` URL; opens the preview when clicked) and an external anchor to the source page. A new pure helper `getGoogleImageResultAnchors` classifies them by href, and the content script tracks which result was enlarged.

## Tests
- Unit tests for the anchor classification across all 201 results in the images snapshot.
- E2E (Playwright): first Enter leaves the results page and opens no popup; second Enter opens the source page in a new tab. Verified the E2E test fails without this change and passes with it.

## Stack
Based on #94 — merge #92 → #93 → #94 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)