### PR TITLE
refactor: inject only real seams, import pure functions directly

### DIFF
--- a/__tests__/highlight.test.ts
+++ b/__tests__/highlight.test.ts
@@ -1,49 +1,43 @@
-// filepath: /Users/n/work/search-navigator/__tests__/highlight.test.ts
-import {
-  makeHighlight,
-  makeUnhighlight,
-} from '../src/services/element-highlighting';
+import { highlight, unhighlight } from '../src/services/element-highlighting';
 import { scrollIntoViewIfOutsideViewport } from '../src/services/dom-utils';
 
-// Mock scrollIntoViewIfOutsideViewport function
+// Mock only the viewport-dependent scrolling; jsdom has no layout, so the
+// real implementation could never report an element as outside the viewport.
 jest.mock('../src/services/dom-utils', () => ({
+  ...jest.requireActual('../src/services/dom-utils'),
   scrollIntoViewIfOutsideViewport: jest.fn().mockImplementation((el) => el),
 }));
 
-describe('makeHighlight', () => {
-  let addClass: jest.Mock;
-  let highlight: ReturnType<typeof makeHighlight>;
+const createResults = (count: number): HTMLElement[] => {
+  document.body.innerHTML = '';
+  return Array.from({ length: count }).map((_, i) => {
+    const div = document.createElement('div');
+    div.id = `result-${i}`;
+    document.body.appendChild(div);
+    return div;
+  });
+};
+
+describe('highlight', () => {
   let results: HTMLElement[];
 
   beforeEach(() => {
-    addClass = jest.fn();
-    highlight = makeHighlight(addClass, scrollIntoViewIfOutsideViewport);
-
-    // Setup DOM elements
-    document.body.innerHTML = '';
-    results = Array.from({ length: 3 }).map((_, i) => {
-      const div = document.createElement('div');
-      div.id = `result-${i}`;
-      document.body.appendChild(div);
-      return div;
-    });
-
-    // Reset mocks
+    results = createResults(3);
     jest.clearAllMocks();
   });
 
   it('should add the correct highlight class', () => {
     highlight(results, 1, 'light');
 
-    expect(addClass).toHaveBeenCalledTimes(1);
-    expect(addClass).toHaveBeenCalledWith(results[1], 'sn-selected-light');
+    expect(results[1].classList.contains('sn-selected-light')).toBe(true);
+    expect(results[0].classList.contains('sn-selected-light')).toBe(false);
+    expect(results[2].classList.contains('sn-selected-light')).toBe(false);
   });
 
   it('should add the dark theme class when specified', () => {
     highlight(results, 0, 'dark');
 
-    expect(addClass).toHaveBeenCalledTimes(1);
-    expect(addClass).toHaveBeenCalledWith(results[0], 'sn-selected-dark');
+    expect(results[0].classList.contains('sn-selected-dark')).toBe(true);
   });
 
   it('should scroll the element into view by default', () => {
@@ -65,34 +59,21 @@ describe('makeHighlight', () => {
   });
 });
 
-describe('makeUnhighlight', () => {
-  let removeClass: jest.Mock;
-  let unhighlight: ReturnType<typeof makeUnhighlight>;
+describe('unhighlight', () => {
   let results: HTMLElement[];
 
   beforeEach(() => {
-    removeClass = jest.fn();
-    unhighlight = makeUnhighlight(removeClass);
-
-    // Setup DOM elements
-    document.body.innerHTML = '';
-    results = Array.from({ length: 3 }).map((_, i) => {
-      const div = document.createElement('div');
-      div.id = `result-${i}`;
-      document.body.appendChild(div);
-      return div;
-    });
-
-    // Reset mocks
+    results = createResults(3);
     jest.clearAllMocks();
   });
 
   it('should remove both light and dark highlight classes', () => {
+    results[1].classList.add('sn-selected-light', 'sn-selected-dark');
+
     unhighlight(results, 1);
 
-    expect(removeClass).toHaveBeenCalledTimes(2);
-    expect(removeClass).toHaveBeenCalledWith(results[1], 'sn-selected-dark');
-    expect(removeClass).toHaveBeenCalledWith(results[1], 'sn-selected-light');
+    expect(results[1].classList.contains('sn-selected-light')).toBe(false);
+    expect(results[1].classList.contains('sn-selected-dark')).toBe(false);
   });
 
   it('should not collapse expanded related questions (keep them open)', () => {
@@ -122,13 +103,13 @@ describe('makeUnhighlight', () => {
   it('should not collapse if no expanded related questions', () => {
     // Setup element without related question pair
     const div = document.createElement('div');
+    div.classList.add('sn-selected-light');
     document.body.appendChild(div);
     results = [div];
 
     unhighlight(results, 0);
 
-    // Just asserting that it doesn't throw an error
-    expect(removeClass).toHaveBeenCalledTimes(2);
+    expect(div.classList.contains('sn-selected-light')).toBe(false);
   });
 
   it('should throw an error for invalid index', () => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,20 +2,18 @@ import {
   PEOPLE_ALSO_ASK_ACCORDION_TIMEOUT,
   UPDATE_KEYMAPPINGS_MESSAGE,
 } from './constants';
+import { keymapManagerPromise } from './dependency-injection';
+import type { PageType } from './services';
 import {
   detectTheme,
+  getGoogleImageResultAnchors,
   getPageType,
   getSearchResults,
   highlight,
-  keymapManagerPromise,
-  unhighlight,
-  waitForSearchRoot,
-} from './dependency-injection';
-import type { PageType } from './services';
-import {
-  getGoogleImageResultAnchors,
   simulateYouTubeHover,
   togglePeopleAlsoAskAccordion,
+  unhighlight,
+  waitForSearchRoot,
 } from './services';
 
 import './style.scss';

--- a/src/dependency-injection.ts
+++ b/src/dependency-injection.ts
@@ -1,42 +1,7 @@
-import {
-  addClass,
-  createKeymapManager,
-  determineThemeFromRgb,
-  extractBackgroundRgb,
-  getGoogleSearchResults,
-  getGoogleSearchTabType,
-  getSearchRootSelector,
-  getYouTubeSearchResults,
-  makeDetectTheme,
-  makeGetPageType,
-  makeGetSearchResults,
-  makeHighlight,
-  makeStorageSync,
-  makeUnhighlight,
-  makeWaitForSearchRoot,
-  removeClass,
-  scrollIntoViewIfOutsideViewport,
-  waitForSelector,
-} from './services';
+import { createKeymapManager, makeStorageSync } from './services';
 
+// Composition root for the browser-extension boundary: only dependencies
+// that wrap Chrome APIs are wired here, so tests can replace them with
+// fakes. Pure services are imported directly where they are used.
 export const storageSync = makeStorageSync(chrome.storage.sync);
 export const keymapManagerPromise = createKeymapManager(storageSync);
-export const detectTheme = makeDetectTheme(
-  extractBackgroundRgb,
-  determineThemeFromRgb
-);
-export const highlight = makeHighlight(
-  addClass,
-  scrollIntoViewIfOutsideViewport
-);
-export const unhighlight = makeUnhighlight(removeClass);
-export const getPageType = makeGetPageType(getGoogleSearchTabType);
-export const getSearchResults = makeGetSearchResults(
-  getGoogleSearchResults,
-  getYouTubeSearchResults
-);
-
-export const waitForSearchRoot = makeWaitForSearchRoot(
-  waitForSelector,
-  getSearchRootSelector
-);

--- a/src/services/element-highlighting.ts
+++ b/src/services/element-highlighting.ts
@@ -1,50 +1,45 @@
 // Element highlighting utilities
-import type { ClassModifier } from './dom-utils';
+import {
+  addClass,
+  removeClass,
+  scrollIntoViewIfOutsideViewport,
+} from './dom-utils';
 
 /**
- * Creates a function that highlights an element at the specified index
+ * Highlights the element at the specified index
  */
-export const makeHighlight =
-  (
-    addClass: ClassModifier,
-    scrollIntoViewIfOutsideViewport: (el: Element) => Element
-  ) =>
-  (
-    results: HTMLElement[],
-    index: number,
-    theme: 'dark' | 'light',
-    options: {
-      scrollIntoView?: boolean;
-    } = { scrollIntoView: true }
-  ): void => {
-    const className = `sn-selected-${theme}`;
-    if (typeof index !== 'number' || index < 0 || index >= results.length) {
-      throw new Error('Invalid index provided for highlight');
-    }
-    const result = results[index];
-    addClass(result, className);
+export const highlight = (
+  results: HTMLElement[],
+  index: number,
+  theme: 'dark' | 'light',
+  options: {
+    scrollIntoView?: boolean;
+  } = { scrollIntoView: true }
+): void => {
+  const className = `sn-selected-${theme}`;
+  if (typeof index !== 'number' || index < 0 || index >= results.length) {
+    throw new Error('Invalid index provided for highlight');
+  }
+  const result = results[index];
+  addClass(result, className);
 
-    // Scroll element into view if needed
-    if (options.scrollIntoView) {
-      scrollIntoViewIfOutsideViewport(results[index]);
-    }
-  };
+  // Scroll element into view if needed
+  if (options.scrollIntoView) {
+    scrollIntoViewIfOutsideViewport(results[index]);
+  }
+};
 
 /**
- * Creates a function that removes highlights from elements
- * If index is provided, only unhighlights that specific element
- * If index is omitted, unhighlights all elements
+ * Removes highlights from the element at the specified index
  */
-export const makeUnhighlight =
-  (removeClass: ClassModifier) =>
-  (results: HTMLElement[], index: number): void => {
-    // throw invalid index
-    if (typeof index === 'number' && (index < 0 || index >= results.length)) {
-      throw new Error('Invalid index provided for unhighlight');
-    }
+export const unhighlight = (results: HTMLElement[], index: number): void => {
+  // throw invalid index
+  if (typeof index === 'number' && (index < 0 || index >= results.length)) {
+    throw new Error('Invalid index provided for unhighlight');
+  }
 
-    // Unhighlight specific element
-    const result = results[index];
-    removeClass(result, 'sn-selected-dark');
-    removeClass(result, 'sn-selected-light');
-  };
+  // Unhighlight specific element
+  const result = results[index];
+  removeClass(result, 'sn-selected-dark');
+  removeClass(result, 'sn-selected-light');
+};

--- a/src/services/get-search-results.ts
+++ b/src/services/get-search-results.ts
@@ -1,3 +1,5 @@
+import { waitForSelector } from './dom-utils';
+
 /**
  * Return an array of visible children (not display:none, not aria-hidden="true").
  */
@@ -109,43 +111,26 @@ export const getYouTubeSearchResults = (
   return Array.from(elements) as HTMLDivElement[];
 };
 
-export const makeGetSearchResults =
-  (
-    getGoogleSearchResults: (
-      tabType: GoogleSearchTabType,
-      doc?: Document
-    ) => HTMLDivElement[],
-    getYouTubeSearchResults: (
-      doc: Document,
-      options?: YouTubeSearchOptions
-    ) => HTMLDivElement[]
-  ) =>
-  (doc: Document, pageType: PageType): HTMLDivElement[] => {
-    if (pageType === 'youtube-search-result') {
-      return getYouTubeSearchResults(doc, {
-        shorts: false,
-        ads: false,
-        mix: true,
-      });
-    }
-    return getGoogleSearchResults(pageType, doc);
-  };
+export const getSearchResults = (
+  doc: Document,
+  pageType: PageType
+): HTMLDivElement[] => {
+  if (pageType === 'youtube-search-result') {
+    return getYouTubeSearchResults(doc, {
+      shorts: false,
+      ads: false,
+      mix: true,
+    });
+  }
+  return getGoogleSearchResults(pageType, doc);
+};
 
-export const makeWaitForSearchRoot =
-  (
-    waitForSelector: (
-      doc: Document,
-      selector: string,
-      timeout?: number
-    ) => Promise<Element>,
-    getSearchRootSelector: (pageType: PageType) => string
-  ) =>
-  async (
-    doc: Document = document,
-    pageType: PageType,
-    timeout = 5_000
-  ): Promise<HTMLDivElement> => {
-    const selector = getSearchRootSelector(pageType);
-    const el = await waitForSelector(doc, selector, timeout);
-    return el as HTMLDivElement;
-  };
+export const waitForSearchRoot = async (
+  doc: Document = document,
+  pageType: PageType,
+  timeout = 5_000
+): Promise<HTMLDivElement> => {
+  const selector = getSearchRootSelector(pageType);
+  const el = await waitForSelector(doc, selector, timeout);
+  return el as HTMLDivElement;
+};

--- a/src/services/search-result-navigation.ts
+++ b/src/services/search-result-navigation.ts
@@ -59,33 +59,25 @@ export function getGoogleSearchTabType(
   return 'all';
 }
 
-export const makeGetPageType =
-  (
-    getGoogleSearchTabType: (
-      urlSearchParams: URLSearchParams
-    ) => GoogleSearchTabType | null
-  ) =>
-  (location: Location): PageType => {
-    const url = new URL(location.href);
+export const getPageType = (location: Location): PageType => {
+  const url = new URL(location.href);
 
-    if (url.hostname === 'www.google.com') {
-      const searchParam = new URLSearchParams(location.search);
-      const tabType = getGoogleSearchTabType(searchParam);
-      if (!tabType) {
-        throw new Error(
-          "Can't determine search tab type for: " + location.href
-        );
-      }
-      return tabType;
+  if (url.hostname === 'www.google.com') {
+    const searchParam = new URLSearchParams(location.search);
+    const tabType = getGoogleSearchTabType(searchParam);
+    if (!tabType) {
+      throw new Error("Can't determine search tab type for: " + location.href);
     }
+    return tabType;
+  }
 
-    if (
-      url.hostname === 'www.youtube.com' &&
-      url.pathname === '/results' &&
-      url.searchParams.has('search_query')
-    ) {
-      return 'youtube-search-result';
-    }
+  if (
+    url.hostname === 'www.youtube.com' &&
+    url.pathname === '/results' &&
+    url.searchParams.has('search_query')
+  ) {
+    return 'youtube-search-result';
+  }
 
-    throw new Error(`Unexpected host: ${url}`);
-  };
+  throw new Error(`Unexpected host: ${url}`);
+};

--- a/src/services/theme-detection.ts
+++ b/src/services/theme-detection.ts
@@ -21,27 +21,15 @@ export function determineThemeFromRgb(
     : 'light';
 }
 
-export const makeDetectTheme =
-  (
-    extractBackgroundRgb: (
-      window: Window & typeof globalThis,
-      el: HTMLElement
-    ) => [number, number, number] | null,
-    determineThemeFromRgb: (
-      rgb: [number, number, number],
-      brightnessThreshold?: number
-    ) => 'light' | 'dark'
-  ) =>
-  (
-    window: Window & typeof globalThis,
-    document: Document,
-    pageType: PageType
-  ): 'light' | 'dark' => {
-    const el =
-      pageType === 'youtube-search-result'
-        ? document.documentElement
-        : document.body;
-    const rgb = extractBackgroundRgb(window, el);
-    const theme = determineThemeFromRgb(rgb || [255, 255, 255]);
-    return theme;
-  };
+export const detectTheme = (
+  window: Window & typeof globalThis,
+  document: Document,
+  pageType: PageType
+): 'light' | 'dark' => {
+  const el =
+    pageType === 'youtube-search-result'
+      ? document.documentElement
+      : document.body;
+  const rgb = extractBackgroundRgb(window, el);
+  return determineThemeFromRgb(rgb || [255, 255, 255]);
+};


### PR DESCRIPTION
## Motivation
The `make*` factory pattern injected even internal pure functions (`addClass`, `determineThemeFromRgb`, `getGoogleSearchTabType`, …) as dependencies. Those functions have exactly one implementation and are never substituted at runtime — injecting them added indirection without buying testability, since they are already easy to test directly with jsdom.

## Principle applied
Inject only what can genuinely vary or crosses a system boundary:

| Dependency | Verdict |
|---|---|
| `chrome.storage.sync` (via `makeStorageSync`) | **Keep injected** — Chrome API adapter, replaced by fakes in tests |
| `createKeymapManager(storage)` | **Keep** — receives the storage seam |
| `Document` / `Window` / `Location` arguments | **Keep as parameters** — data passed in, which is what lets jsdom tests work |
| `makeHighlight`, `makeUnhighlight`, `makeDetectTheme`, `makeGetPageType`, `makeGetSearchResults`, `makeWaitForSearchRoot` | **Unwrapped** — now plain functions importing their helpers directly |

`dependency-injection.ts` shrinks from 9 wired exports to the two genuine Chrome-bound singletons (43 → 7 lines). Net −96 lines.

## Tests
- `highlight.test.ts` now asserts real `classList` changes instead of counting mock calls; only the viewport-dependent scrolling is mocked (jsdom has no layout).
- All 69 unit tests and 7 Playwright E2E tests pass.

## Stack
Based on #96 — **merge #96 first (and delete its branch so this PR retargets to main)**, then merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)