### PR TITLE
chore: prepare release 1.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+## [1.9.5] - 2026-07-04
+
 ### Fixed
 
 - Fix tab type detection on search URLs with `udm=1` (Web tab); recognize `udm` Web variants and fall back to the default tab type instead of throwing on unknown `tbm`/`udm` values (#90)
+- Include results loaded by infinite scroll into `#botstuff` in All tab navigation. (#76)
+- Stabilize YouTube search result navigation: remove stale keydown listeners piling up across SPA navigations, scope the search root to `ytd-search #contents`, and recover when results have not rendered yet. (#73)
+
+### Changed
+
+- On the Images tab, Enter now opens the preview (enlarge) panel and pressing Enter again opens the image's source page; Ctrl/Cmd/Shift+Enter opens the source page directly. (#72)
+
+### Maintenance
+
+- Add Playwright E2E tests that load the built extension and run against saved page snapshots without network access. (#92)
+- Refactor dependency injection to wire only the Chrome API boundary; pure functions are now imported directly. (#97)
+
+## [1.9.4] - 2025-08-14
+
+### Fixed
+
 - Fix arrow key navigation not called when modifier keys are pressed (#87)
 
 ## [1.9.3] - 2025-08-12

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Search navigator",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Navigate search results with shortcuts",
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
## Release 1.9.5

Bumps `manifest.json` to 1.9.5 and updates the changelog.

### Included since v1.9.4
**Fixed**
- Tab type detection on `udm=1` URLs; unknown `tbm`/`udm` values fall back instead of throwing (#90)
- Navigation into infinite-scroll results loaded into `#botstuff` on the All tab (#76)
- YouTube search result navigation stability (#73)

**Changed**
- Images tab: Enter opens the preview panel, Enter again opens the source page (#72)

**Maintenance**
- Playwright E2E infrastructure (#92)
- DI refactor: wire only the Chrome API boundary (#97)

### Changelog repair
The `[Unreleased]` section still held the #87 entry that shipped in v1.9.4 (the `[1.9.4]` heading was never created). This PR adds the missing `## [1.9.4] - 2025-08-14` heading. Since #90 was merged after the v1.9.4 tag, it is listed under 1.9.5.

### After merging
Tag `v1.9.5` on the merge commit and publish the GitHub release — tell me once merged and I'll do it, or:
```
git tag v1.9.5 <merge-commit> && git push origin v1.9.5
gh release create v1.9.5 --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)