### PR TITLE
chore: prepare release 1.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+## [1.9.6] - 2026-07-04
+
+### Fixed
+
+- Make YouTube playlist, course and Mix results selectable again: they render as `yt-lockup-view-model` host elements, and the CSS classes the old selector relied on were removed from YouTube's DOM. (#100)
+
+### Maintenance
+
+- Add E2E regression tests for previously uncaught errors (warmup page, SPA navigation to a watch page, empty result list). (#99)
+
 ## [1.9.5] - 2026-07-04
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Search navigator",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Navigate search results with shortcuts",
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
## Release 1.9.6

Bumps `manifest.json` to 1.9.6 and updates the changelog.

### Included since v1.9.5
**Fixed**
- YouTube playlist / course / Mix results selectable again (#100)

**Maintenance**
- E2E regression tests for previously uncaught errors (#99)

### Store note
v1.9.5 was tagged and released on GitHub but never uploaded to the Chrome Web Store; the store upload will go straight from the current store version to 1.9.6 (version numbers only need to increase, gaps are fine).

### After merging
Tag `v1.9.6` on the merge commit, publish the GitHub release, and upload the 1.9.6 zip to the store (instead of the 1.9.5 one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)