### PR TITLE
docs: mark YouTube navigation as stable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Navigate Google search results with your keyboard:
 - `h/l` or `←/→` - Previous/next page
 - `Enter` - Open result (+ `Ctrl`/`Cmd` for new tab, `Shift` for new window)
 
-  _Note: Navigation controls are currently not supported on Shopping pages_
+  _Note: Navigation controls are not supported on Shopping pages_
 
 **Switch Between Tabs**
 
@@ -48,17 +48,14 @@ Navigate Google search results with your keyboard:
 
 **Customize shortcuts** by clicking the extension icon. Arrow keys cannot be changed.
 
-## Important Notes
-
-⚠️ **YouTube functionality is currently unstable and in preview version.** Navigation features may not work consistently on YouTube Search Result pages. Full YouTube support is planned for future releases.
-
 ## Roadmap
 
 - [x] Light/Dark Theme support
 - [x] Keyboard shortcut customization
 - [x] Switch between All, Images, Videos, News, and Shopping search tabs
 - [x] Navigate to Google Maps and YouTube with current search query
-- [ ] YouTube support: move up/down, open, save to “Watch Later”
+- [x] YouTube support: move up/down, open
+- [ ] YouTube support: save to “Watch Later”
 - [x] Image/Video/News support: move up/down, open
 
 ## Developer Contribution Guidelines


### PR DESCRIPTION
## What changed

- Removed the **Important Notes** section warning that YouTube functionality is unstable/preview.
- Roadmap: checked off "YouTube support: move up/down, open" and split "save to Watch Later" into its own pending item.
- Reworded the Shopping note from "currently not supported" to "not supported" to reflect that Shopping navigation is out of scope by design, not pending work.

## Why

YouTube search-result navigation shipped in 1.9.0 and was stabilized by the 1.9.5 fixes (stale keydown listeners, SPA navigation) and the 1.9.6 selector fix for playlist/course/Mix results, so the unstable-preview warning no longer applies. This also aligns the README with the updated Chrome Web Store listing for 1.9.6.

## Notes for reviewer

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)