### PR TITLE
Growth: Chrome Web Store ASO + in-app rating prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+### Changed
+
+- Optimize the store listing for discoverability: keyword-rich extension `name` and `description` in the manifest, plus a `short_name` for cramped surfaces.
+
 ## [1.9.6] - 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+### Added
+
+- In-page rating prompt: after opening enough search results, a one-time, dismissible toast invites a Chrome Web Store rating. The open counter is stored locally in `chrome.storage.sync`; no tracking and no external requests (clicking "Rate" opens the store page).
+
 ### Changed
 
 - Optimize the store listing for discoverability: keyword-rich extension `name` and `description` in the manifest, plus a `short_name` for cramped surfaces.

--- a/__tests__/rate-prompt-toast.test.ts
+++ b/__tests__/rate-prompt-toast.test.ts
@@ -1,0 +1,47 @@
+import {
+  createRatePromptToast,
+  RATE_PROMPT_TOAST_ID,
+} from '../src/services/rate-prompt-toast';
+
+describe('createRatePromptToast', () => {
+  it('builds a themed, detached toast with a stable id', () => {
+    const toast = createRatePromptToast('dark', {
+      onRate: jest.fn(),
+      onDismiss: jest.fn(),
+    });
+    expect(toast.id).toBe(RATE_PROMPT_TOAST_ID);
+    expect(toast.className).toContain('sn-rate-prompt-dark');
+    expect(toast.getAttribute('role')).toBe('dialog');
+    // Not attached to the document until the caller appends it.
+    expect(toast.isConnected).toBe(false);
+  });
+
+  it('wires the Rate button to onRate', () => {
+    const onRate = jest.fn();
+    const onDismiss = jest.fn();
+    const toast = createRatePromptToast('light', { onRate, onDismiss });
+
+    const rate = toast.querySelector(
+      '.sn-rate-prompt__btn--primary'
+    ) as HTMLButtonElement;
+    rate.click();
+
+    expect(onRate).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('wires the "Not now" button to onDismiss', () => {
+    const onRate = jest.fn();
+    const onDismiss = jest.fn();
+    const toast = createRatePromptToast('light', { onRate, onDismiss });
+
+    const buttons = toast.querySelectorAll('.sn-rate-prompt__btn');
+    const dismiss = Array.from(buttons).find(
+      (b) => !b.classList.contains('sn-rate-prompt__btn--primary')
+    ) as HTMLButtonElement;
+    dismiss.click();
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onRate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/rating-prompt.test.ts
+++ b/__tests__/rating-prompt.test.ts
@@ -1,0 +1,108 @@
+import type { ChromeStorage } from '../src/services/chrome-storage';
+import {
+  defaultRatingState,
+  getRatingState,
+  incrementOpens,
+  markDismissed,
+  markRated,
+  RATE_PROMPT_OPENS_THRESHOLD,
+  saveRatingState,
+  shouldShowRatePrompt,
+  type RatingState,
+} from '../src/services/rating-prompt';
+
+describe('rating-prompt pure transitions', () => {
+  describe('incrementOpens', () => {
+    it('increments while pending and below the threshold', () => {
+      expect(incrementOpens({ opens: 0, status: 'pending' })).toEqual({
+        opens: 1,
+        status: 'pending',
+      });
+    });
+
+    it('caps at the threshold and returns the same reference (no redundant write)', () => {
+      const atCap: RatingState = {
+        opens: RATE_PROMPT_OPENS_THRESHOLD,
+        status: 'pending',
+      };
+      expect(incrementOpens(atCap)).toBe(atCap);
+    });
+
+    it('does not count once the prompt is resolved', () => {
+      const rated: RatingState = { opens: 3, status: 'rated' };
+      const dismissed: RatingState = { opens: 3, status: 'dismissed' };
+      expect(incrementOpens(rated)).toBe(rated);
+      expect(incrementOpens(dismissed)).toBe(dismissed);
+    });
+  });
+
+  describe('markRated / markDismissed', () => {
+    it('sets status without mutating the input', () => {
+      const state: RatingState = { opens: 5, status: 'pending' };
+      expect(markRated(state)).toEqual({ opens: 5, status: 'rated' });
+      expect(markDismissed(state)).toEqual({ opens: 5, status: 'dismissed' });
+      expect(state.status).toBe('pending');
+    });
+  });
+
+  describe('shouldShowRatePrompt', () => {
+    it('is true only when pending and at/over the threshold', () => {
+      expect(
+        shouldShowRatePrompt({
+          opens: RATE_PROMPT_OPENS_THRESHOLD,
+          status: 'pending',
+        })
+      ).toBe(true);
+    });
+
+    it('is false below the threshold', () => {
+      expect(
+        shouldShowRatePrompt({
+          opens: RATE_PROMPT_OPENS_THRESHOLD - 1,
+          status: 'pending',
+        })
+      ).toBe(false);
+    });
+
+    it('is false once rated or dismissed even past the threshold', () => {
+      const opens = RATE_PROMPT_OPENS_THRESHOLD + 5;
+      expect(shouldShowRatePrompt({ opens, status: 'rated' })).toBe(false);
+      expect(shouldShowRatePrompt({ opens, status: 'dismissed' })).toBe(false);
+    });
+  });
+});
+
+describe('rating-prompt storage adapters', () => {
+  let mockStorage: jest.Mocked<ChromeStorage>;
+
+  beforeEach(() => {
+    mockStorage = {
+      get: jest.fn(),
+      set: jest.fn(),
+      remove: jest.fn(),
+      clear: jest.fn(),
+    };
+  });
+
+  it('returns defaults when nothing is stored', async () => {
+    mockStorage.get.mockResolvedValue({});
+    await expect(getRatingState(mockStorage)).resolves.toEqual(
+      defaultRatingState
+    );
+  });
+
+  it('merges stored state over the defaults', async () => {
+    mockStorage.get.mockResolvedValue({ rating_state: { opens: 7 } });
+    await expect(getRatingState(mockStorage)).resolves.toEqual({
+      opens: 7,
+      status: 'pending',
+    });
+  });
+
+  it('persists under the rating_state key', async () => {
+    mockStorage.set.mockResolvedValue();
+    const state: RatingState = { opens: 2, status: 'pending' };
+    await saveRatingState(mockStorage, state);
+    expect(mockStorage.set).toHaveBeenCalledWith({ rating_state: state });
+  });
+});

--- a/docs/growth-playbook.md
+++ b/docs/growth-playbook.md
@@ -1,0 +1,283 @@
+# Search Navigator — Growth Playbook
+
+The single home for go-to-market strategy that has **no other place to live**.
+Copy that belongs in a system of record lives there, not here (see the table below).
+
+## Source-of-truth map (avoid double management)
+
+| Asset | Canonical home (edit only here) | Not duplicated in |
+| --- | --- | --- |
+| Extension title + summary | `manifest.json` (`name`, `description`) | this doc |
+| Full description, screenshots, promo video, JP listing | Chrome Web Store dashboard → Store listing | this repo |
+| Positioning, launch posts, keyword rationale, screenshot plan | **this file** | — (its only home) |
+
+The store description drafts are kept once, in the clearly-marked seed appendix at the
+bottom; delete that appendix once it's pasted into the dashboard.
+
+---
+
+## 1. Diagnosis
+
+~967 users at 4.5★ (15 ratings) despite a polished product → the bottleneck is
+**discovery, not features**. A well-built tool with few users has a distribution problem.
+
+First-party evidence:
+- **Issue #89 "Hard to find this extension":** *"exactly what I've been looking for — a
+  google search navigator with up and down or j/k keys — but it was too hard to find."*
+  Confirms the bottleneck AND reveals the exact phrase users type.
+- **Issues #74 & #11:** users arrive here as **refugees from "Web Search Navigator"**,
+  which they report is "not useable anymore."
+
+Biggest unlock — **Web Search Navigator refugees.** That incumbent
+(`cohamjploocgoejdfanacfgkhjkhdkek`) has ~4,000 users, 4.9★/260 ratings, but was last
+updated **May 2023**. A large, warm, orphaned audience actively seeking a maintained
+replacement.
+
+Priority order (highest ROI first): **1) store ASO → 2) in-app review prompt →
+3) positioning → 4) launch.** Features rarely drive acquisition (non-users can't see
+them); only **broader site support** widens the funnel.
+
+---
+
+## 2. Positioning (the through-line for everything)
+
+> **Keyboard navigation for Google & YouTube search — the actively-maintained,
+> open-source successor to Web Search Navigator. j/k or arrows, zero setup, no tracking.**
+
+Short taglines (pick per surface):
+- "Search results at keyboard speed — j/k for Google & YouTube."
+- "The maintained keyboard navigator for Google Search & YouTube."
+- "Vim-style search navigation, without the Vimium learning curve."
+
+Three concentric audiences (target warmest first):
+1. **Web Search Navigator refugees** — warmest. *"the maintained successor."*
+2. **People searching the exact phrase** (#89) — *"google search navigator j/k keys",
+   "web search navigator alternative".* Captured via store keywords + a ranking blog post.
+3. **Vim / keyboard power users** who find Vimium too heavy — *"search-focused, nothing
+   to memorize; it doesn't remap your whole browser."*
+
+Differentiators to lead with:
+- **Maintained** (vs the abandoned incumbents) — updated for today's Google/YouTube DOM.
+- **Zero setup** — useful the second it's installed.
+- **Search-focused** — no full-browser remap (vs Vimium/Surfingkeys).
+- **Google + YouTube + tab switching + Maps/YouTube jump** — broader than pure arrow tools.
+- **Private & open source (MIT)** — no data collection, tracking, or external requests.
+
+Quick wins that would convert the refugee pool (requested, **not yet built**):
+- Space to open the selected result (#11).
+- Multiple key bindings for "Open link" (#74).
+Shipping these later would let the launch say *"everything you had, still maintained."*
+They are functional changes, so keep them out of discovery-focused work and ship them
+on their own.
+
+---
+
+## 3. Store ASO (keyword rationale + assets)
+
+Title/summary already live in `manifest.json`. Keyword sources — weave naturally, do not
+stuff:
+> **google search navigator, keyboard shortcuts for google, arrow keys / j k navigation,
+> navigate search results without a mouse, web search navigator alternative,
+> vim google search.**
+(These come from issue #89's real user language and the orphaned incumbent's name.)
+
+### Screenshots / promo video (biggest single conversion lever)
+
+Store allows 5 screenshots (1280×800 or 640×400) + an optional YouTube promo video.
+**Tile 1 must sell the core motion** (ideally an animated hero / short recording).
+
+1. **Hero** — Google results, one highlighted, key-cap overlay `j` `k`.
+   *"Move through results with j / k — never touch the mouse"*
+2. **Tab switching** — the a/i/v/n/s row highlighted.
+   *"Jump between All · Images · Videos · News · Shopping"*
+3. **Open anywhere** — `Enter` / `Cmd+Enter` opening a new tab.
+   *"Open results in place or in a new tab — from the keyboard"*
+4. **YouTube** — results navigation on youtube.com.
+   *"Same shortcuts on YouTube"*
+5. **Customize** — popup with the remap UI + dark theme.
+   *"Remap any key · light & dark"*
+
+Promo video: 15–25s recording of a real session (type query → j/k → Enter → switch to
+Images → open). Small promo tile (440×280) unlocks featured placement — worth making.
+
+---
+
+## 4. Launch (spike + ratings + durable backlinks)
+
+Lead angle everywhere: **the actively-maintained, open-source successor to the abandoned
+Web Search Navigator** + the honest hook that a real user called it *"exactly what I've
+been looking for… but too hard to find."*
+
+Sequence (space them so each feeds the next):
+1. **Blog / dev.to** (do first — durable backlink) →
+2. **Reddit** (r/chrome, r/productivity, r/vim — one at a time, days apart) →
+3. **Show HN** →
+4. **Product Hunt** (needs the screenshots/video above).
+
+### Show HN
+
+**Title:** `Show HN: Search Navigator – keyboard navigation for Google & YouTube (j/k, no setup)`
+
+**Body:**
+```
+I use the keyboard for everything, and the extension I relied on to move through Google
+results with j/k — Web Search Navigator — stopped being maintained (last update 2023) and
+started breaking as Google changed its markup. So I built and now actively maintain a
+replacement.
+
+Search Navigator lets you:
+- move through results with j/k or arrow keys, open with Enter (Cmd/Ctrl = new tab)
+- switch tabs from the keyboard: a All, i Images, v Videos, n News, s Shopping
+- jump to Google Maps (m) or YouTube (y) with your current query
+- do the same on YouTube search
+
+Design choices:
+- Zero config — it works the moment it's installed.
+- Search-result focused on purpose. It doesn't remap your whole browser like Vimium, so
+  there's essentially nothing to learn.
+- No data collection, no tracking, no external requests. MIT, source is on GitHub.
+
+It handles the annoying real-world cases: infinite scroll, "People also ask", SPA
+navigation on YouTube, image preview panels. Tested with unit + Playwright E2E against
+saved page snapshots.
+
+Store: <link>   Source: https://github.com/nwatab/search-navigator
+
+Happy to talk about the pain of scraping Google's ever-changing DOM — that's most of the
+maintenance work, and why the unmaintained alternatives break.
+```
+Be present in the comments for the first few hours; the "why the old ones break" thread is
+the strongest asset.
+
+### Reddit
+
+Lead with the story/problem, link once, engage. One sub at a time.
+
+**Title (r/chrome, r/productivity):**
+`I rebuilt the abandoned "Web Search Navigator" so you can drive Google & YouTube with j/k again`
+**Title (r/vim):**
+`Vim-style j/k navigation for Google & YouTube search, without remapping your whole browser`
+**Body:**
+```
+If you ever used Web Search Navigator to move through Google results with j/k and noticed
+it breaking (it hasn't been updated since 2023), I made a maintained, open-source
+replacement: Search Navigator.
+
+j/k or arrows to move, Enter to open (Cmd/Ctrl for a new tab), a/i/v/n/s to
+switch tabs, m/y to jump to Maps/YouTube. Works on YouTube search too. Zero setup,
+remappable keys, light/dark, and — because I know this sub cares — no tracking and no
+external requests. MIT-licensed, code's on GitHub.
+
+Not trying to be Vimium; it stays focused on search results so there's nothing to learn.
+Feedback and bug reports welcome — Google changes its DOM constantly and I'd rather hear
+it here than have it silently break.
+
+Store: <link>   Source: <github>
+```
+
+### Product Hunt
+
+**Tagline:** `Drive Google & YouTube search with your keyboard`
+**Description:**
+```
+Search Navigator adds fast, Vim-style keyboard shortcuts to Google Search and YouTube:
+move through results with j/k or arrows, open with Enter, switch between All/Images/
+Videos/News/Shopping, and jump to Maps or YouTube — all without touching the mouse.
+
+Zero setup, remappable keys, light/dark, and genuinely private: no data collection, no
+tracking, no external requests. Open source (MIT). It's the actively-maintained successor
+to the beloved-but-abandoned Web Search Navigator.
+```
+**Maker's first comment:**
+```
+Hi PH 👋 I built this because the keyboard-navigation extension I depended on stopped
+being maintained and started breaking on new Google layouts. Search Navigator is my
+maintained, open-source take — focused only on search results, so there's nothing to
+learn. Would love your feedback, especially edge cases where Google's markup trips it up.
+```
+
+### Blog / dev.to (do first — durable backlink)
+
+**Title:** `Keeping a Chrome extension alive against Google's ever-changing DOM`
+The engineering story — how result-scraping breaks when Google ships new markup, detecting
+tab types across `tbm`/`udm`, testing with Playwright against saved snapshots. Ends with
+"I maintain Search Navigator, the successor to Web Search Navigator." Earns interest on
+merit and leaves a permanent, keyword-rich backlink.
+
+---
+
+## 5. After launch
+
+Only one feature area widens the acquisition funnel: **broader site support**
+(Bing, DuckDuckGo, Brave Search, Startpage, etc.) — each adds new store keywords and a new
+user segment, while keeping the "search-focused, zero-config" wedge. Prioritize by the
+request data the launch surfaces; don't build ahead of demand.
+
+---
+
+## Appendix — store description SEED (delete after pasting into the CWS dashboard)
+
+> One-time copy to paste into the Chrome Web Store dashboard. Once applied, the dashboard
+> is the source of truth — delete this appendix so it isn't maintained in two places.
+
+**EN full description**
+```
+Browse Google Search and YouTube entirely from your keyboard.
+
+Search Navigator adds fast, Vim-style shortcuts so you can move through results, open
+links, flip pages, and jump between Images / Videos / News / Shopping — without ever
+reaching for the mouse. It works the moment you install it. No configuration.
+
+▸ NAVIGATION
+  • j / k  or  ↓ / ↑   — move through results
+  • h / l  or  ← / →   — previous / next page
+  • Enter — open result  (Ctrl/Cmd = new tab, Shift = new window)
+
+▸ SWITCH TABS
+  • a All · i Images · v Videos · n News · s Shopping
+
+▸ QUICK ACCESS
+  • m — Google Maps · y — YouTube  (carries your current query)
+
+▸ YOUTUBE
+  • Navigate and open search results with the same keys
+
+▸ COMING FROM WEB SEARCH NAVIGATOR?
+  • Search Navigator is an actively-maintained, open-source alternative with the same
+    j/k navigation — kept working on today's Google and YouTube.
+
+▸ WHY SEARCH NAVIGATOR
+  • Zero setup, remappable shortcuts, automatic light / dark theme
+  • Search-result focused, so there's nothing to memorize
+  • Open source (MIT) — read every line yourself
+
+▸ PRIVACY
+  • No data collection. No tracking. No external requests. Ever.
+```
+
+**JP full description**
+```
+Google 検索と YouTube を、キーボードだけで操作。
+
+Search Navigator は Vim 風のショートカットを追加します。検索結果の移動、リンクを開く、
+ページ送り、画像／動画／ニュース／ショッピングの切り替えまで、マウスに手を伸ばさず完結。
+インストールした瞬間から使えます。設定不要。
+
+▸ 移動
+  • j / k または ↓ / ↑ — 結果を移動
+  • h / l または ← / → — 前 / 次のページ
+  • Enter — 結果を開く（Ctrl/Cmd で新規タブ、Shift で新規ウィンドウ）
+
+▸ タブ切り替え
+  • a すべて · i 画像 · v 動画 · n ニュース · s ショッピング
+
+▸ クイックアクセス
+  • m — Google マップ · y — YouTube（今の検索語をそのまま渡す）
+
+▸ Web Search Navigator を使っていた方へ
+  • 同じ j/k ナビゲーションを、現在も保守されているオープンソースで。今の Google /
+    YouTube に合わせて更新し続けています。
+
+▸ プライバシー
+  • データ収集なし。トラッキングなし。外部通信なし。
+```

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Search navigator",
+  "name": "Search Navigator – Keyboard shortcuts for Google & YouTube",
+  "short_name": "Search Navigator",
   "version": "1.9.6",
-  "description": "Navigate search results with shortcuts",
+  "description": "Keyboard shortcuts for Google Search & YouTube. Move with j/k, switch tabs, open results — no mouse, no setup, no tracking.",
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,14 +2,24 @@ import {
   PEOPLE_ALSO_ASK_ACCORDION_TIMEOUT,
   UPDATE_KEYMAPPINGS_MESSAGE,
 } from './constants';
-import { keymapManagerPromise } from './dependency-injection';
+import { keymapManagerPromise, storageSync } from './dependency-injection';
 import type { PageType } from './services';
 import {
+  createRatePromptToast,
+  defaultRatingState,
   detectTheme,
   getGoogleImageResultAnchors,
   getPageType,
+  getRatingState,
   getSearchResults,
   highlight,
+  incrementOpens,
+  markDismissed,
+  markRated,
+  RATE_PROMPT_TOAST_ID,
+  RATE_URL,
+  saveRatingState,
+  shouldShowRatePrompt,
   simulateYouTubeHover,
   togglePeopleAlsoAskAccordion,
   unhighlight,
@@ -23,6 +33,41 @@ import './style.scss';
   // init() re-runs on SPA navigation (yt-navigate-finish, popstate). Abort the
   // previous keydown listener so each keypress is handled exactly once (issue #73).
   let keydownAbortController: AbortController | null = null;
+
+  // Rating nudge: count genuine result-opens and, once past the threshold, show
+  // a single dismissible toast asking for a store rating. All local; no tracking.
+  let ratingState = await getRatingState(storageSync).catch(
+    () => defaultRatingState
+  );
+  let ratePromptHandled = false;
+
+  const recordResultOpen = () => {
+    const next = incrementOpens(ratingState);
+    if (next === ratingState) return;
+    ratingState = next;
+    void saveRatingState(storageSync, ratingState).catch(() => {});
+  };
+
+  const maybeShowRatePrompt = (theme: 'light' | 'dark') => {
+    if (ratePromptHandled) return;
+    ratePromptHandled = true;
+    if (!shouldShowRatePrompt(ratingState)) return;
+    if (document.getElementById(RATE_PROMPT_TOAST_ID)) return;
+    const toast = createRatePromptToast(theme, {
+      onRate: () => {
+        window.open(RATE_URL, '_blank', 'noopener');
+        ratingState = markRated(ratingState);
+        void saveRatingState(storageSync, ratingState).catch(() => {});
+        toast.remove();
+      },
+      onDismiss: () => {
+        ratingState = markDismissed(ratingState);
+        void saveRatingState(storageSync, ratingState).catch(() => {});
+        toast.remove();
+      },
+    });
+    document.body.appendChild(toast);
+  };
 
   async function init() {
     keydownAbortController?.abort();
@@ -56,6 +101,9 @@ import './style.scss';
       );
     }
     const theme = detectTheme(window, document, pageType);
+
+    // Ask for a rating once the user has opened enough results (fire-and-forget).
+    maybeShowRatePrompt(theme);
 
     // Results may not be rendered yet (YouTube streams them in). Pressing
     // move_down re-queries, so navigation recovers once they appear.
@@ -171,6 +219,7 @@ import './style.scss';
               return;
             }
             if (!source?.href) return;
+            recordResultOpen();
             if (ctrlKey || metaKey) {
               window.open(source.href, '_blank');
             } else if (shiftKey) {
@@ -218,6 +267,7 @@ import './style.scss';
             'a[href]'
           ) as HTMLAnchorElement;
           if (!link?.href) return;
+          recordResultOpen();
           const { ctrlKey, metaKey, shiftKey } = e;
           if (ctrlKey || metaKey) {
             // Ctrl+Click or Cmd+Click → new tab

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,5 @@ export * from './theme-detection';
 export * from './keymap-manager';
 export * from './chrome-storage';
 export * from './keymap-utils';
+export * from './rating-prompt';
+export * from './rate-prompt-toast';

--- a/src/services/rate-prompt-toast.ts
+++ b/src/services/rate-prompt-toast.ts
@@ -1,0 +1,42 @@
+export const RATE_PROMPT_TOAST_ID = 'sn-rate-prompt';
+
+export interface RatePromptToastHandlers {
+  onRate: () => void;
+  onDismiss: () => void;
+}
+
+// Pure DOM factory: builds a detached, dismissible toast. The caller decides
+// when to append it and what the handlers do, keeping this free of side effects.
+export const createRatePromptToast = (
+  theme: 'light' | 'dark',
+  handlers: RatePromptToastHandlers
+): HTMLElement => {
+  const toast = document.createElement('div');
+  toast.id = RATE_PROMPT_TOAST_ID;
+  toast.className = `sn-rate-prompt sn-rate-prompt-${theme}`;
+  toast.setAttribute('role', 'dialog');
+  toast.setAttribute('aria-label', 'Rate Search Navigator');
+
+  const message = document.createElement('span');
+  message.className = 'sn-rate-prompt__message';
+  message.textContent = 'Enjoying Search Navigator?';
+
+  const actions = document.createElement('div');
+  actions.className = 'sn-rate-prompt__actions';
+
+  const rateButton = document.createElement('button');
+  rateButton.type = 'button';
+  rateButton.className = 'sn-rate-prompt__btn sn-rate-prompt__btn--primary';
+  rateButton.textContent = 'Rate ★';
+  rateButton.addEventListener('click', handlers.onRate);
+
+  const dismissButton = document.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.className = 'sn-rate-prompt__btn';
+  dismissButton.textContent = 'Not now';
+  dismissButton.addEventListener('click', handlers.onDismiss);
+
+  actions.append(rateButton, dismissButton);
+  toast.append(message, actions);
+  return toast;
+};

--- a/src/services/rating-prompt.ts
+++ b/src/services/rating-prompt.ts
@@ -1,0 +1,60 @@
+import type { ChromeStorage } from './chrome-storage';
+
+// Chrome Web Store reviews page for this extension.
+export const RATE_URL =
+  'https://chromewebstore.google.com/detail/fpinaaaiplppifhmkjdfkimodkkdnoha/reviews';
+
+// How many result-opens a user makes before we ask, once, for a rating.
+export const RATE_PROMPT_OPENS_THRESHOLD = 15;
+
+const STORAGE_KEY = 'rating_state';
+
+export type RatePromptStatus = 'pending' | 'rated' | 'dismissed';
+
+export interface RatingState {
+  readonly opens: number;
+  readonly status: RatePromptStatus;
+}
+
+export const defaultRatingState: RatingState = { opens: 0, status: 'pending' };
+
+// --- pure state transitions ---
+
+// Count one result-open. Stops once the prompt is resolved or already due, so
+// the stored counter (and its sync writes) stay bounded. Returns the same
+// reference when nothing changes, so callers can skip a redundant write.
+export const incrementOpens = (state: RatingState): RatingState =>
+  state.status !== 'pending' || state.opens >= RATE_PROMPT_OPENS_THRESHOLD
+    ? state
+    : { ...state, opens: state.opens + 1 };
+
+export const markRated = (state: RatingState): RatingState => ({
+  ...state,
+  status: 'rated',
+});
+
+export const markDismissed = (state: RatingState): RatingState => ({
+  ...state,
+  status: 'dismissed',
+});
+
+export const shouldShowRatePrompt = (
+  state: RatingState,
+  threshold: number = RATE_PROMPT_OPENS_THRESHOLD
+): boolean => state.status === 'pending' && state.opens >= threshold;
+
+// --- storage adapters (the only Chrome API seam here) ---
+
+export const getRatingState = async (
+  storage: ChromeStorage
+): Promise<RatingState> => {
+  const stored = await storage.get<{ rating_state?: Partial<RatingState> }>(
+    STORAGE_KEY
+  );
+  return { ...defaultRatingState, ...(stored?.rating_state ?? {}) };
+};
+
+export const saveRatingState = (
+  storage: ChromeStorage,
+  state: RatingState
+): Promise<void> => storage.set({ [STORAGE_KEY]: state });

--- a/src/style.scss
+++ b/src/style.scss
@@ -12,3 +12,79 @@
   background-color: rgba(240, 240, 240, 0.3) !important;
   border-radius: 8px !important;
 }
+
+/* One-time, dismissible "rate this extension" toast (bottom-right). */
+.sn-rate-prompt {
+  position: fixed !important;
+  bottom: 20px !important;
+  right: 20px !important;
+  z-index: 2147483647 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 280px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  animation: sn-rate-prompt-in 0.2s ease-out;
+}
+
+@keyframes sn-rate-prompt-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sn-rate-prompt-light {
+  background: #ffffff;
+  color: #202124;
+  border: 1px solid #dadce0;
+}
+
+.sn-rate-prompt-dark {
+  background: #2d2e30;
+  color: #e8eaed;
+  border: 1px solid #5f6368;
+}
+
+.sn-rate-prompt__message {
+  font-weight: 600;
+}
+
+.sn-rate-prompt__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.sn-rate-prompt__btn {
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: none;
+  font-size: 13px;
+  font-family: inherit;
+  background: transparent;
+  color: inherit;
+}
+
+.sn-rate-prompt__btn:hover {
+  background: rgba(128, 128, 128, 0.15);
+}
+
+.sn-rate-prompt__btn--primary {
+  background: #1a73e8;
+  color: #ffffff;
+}
+
+.sn-rate-prompt__btn--primary:hover {
+  background: #1b66c9;
+}


### PR DESCRIPTION
## Why

The extension is polished (4.5★) but under-discovered (~967 users). First-party evidence says the bottleneck is **discovery, not features** — issue #89 ("Hard to find this extension"), and users migrating from the abandoned **Web Search Navigator** (~4k users, last updated 2023) who find this as its successor. This PR is **discovery-only** — no functional/keymap changes.

## What's in it (3 commits)

1. **`feat(store)`** — keyword-rich `name`/`description` + `short_name` in the manifest, so the Chrome Web Store listing ranks and converts. (Ships on next republish.)
2. **`feat(rating)`** — a local, one-time, dismissible in-page rating toast after enough result-opens. `chrome.storage.sync` only; **no tracking, no external requests**. Threshold is one tunable constant.
3. **`docs`** — a consolidated growth playbook (positioning, launch posts, keyword/screenshot guidance) with a source-of-truth map so listing copy isn't managed twice.

## Verification

- `tsc` ✓ · unit **84 passing** (added: rating model + toast DOM factory) ✓ · prod build ✓ · Playwright **E2E 11/11** (no navigation regression) ✓
- Drove the built popup in a browser to sanity-check rendering.

## Notes

- Store full description / screenshots / JP listing are set in the CWS dashboard (see `docs/growth-playbook.md`), not code.
- The #11/#74 shortcut features (Enter+Space / multi-key) were intentionally **left out** of this PR to keep it discovery-only; they're noted in the playbook as separate, future functional work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)