### PR TITLE
chore: prepare release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-12
+
 ### Added
 
 - In-page rating prompt: after opening enough search results, a one-time, dismissible toast invites a Chrome Web Store rating. The open counter is stored locally in `chrome.storage.sync`; no tracking and no external requests (clicking "Rate" opens the store page).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Search Navigator – Keyboard shortcuts for Google & YouTube",
   "short_name": "Search Navigator",
-  "version": "1.9.6",
+  "version": "1.10.0",
   "description": "Keyboard shortcuts for Google Search & YouTube. Move with j/k, switch tabs, open results — no mouse, no setup, no tracking.",
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
Prepare the 1.10.0 release (follows the same convention as #101 / prepare-1.9.6).

- Bump `manifest.json` version 1.9.6 → 1.10.0.
- Finalize the CHANGELOG: move the Unreleased entries under `## [1.10.0] - 2026-07-12`.
  - Added: local, one-time in-app rating prompt.
  - Changed: Chrome Web Store listing ASO (keyword-rich `name`/`description`, `short_name`).

`package.json` version is left at 1.0.0, per existing convention.

After merge: tag `v1.10.0`, create the GitHub release, then build + zip `dist/` and upload to the Chrome Web Store dashboard for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)