### PR TITLE
feat(i18n): add _locales (en, ja) to enable a Japanese store listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+### Added
+
+- Internationalization (`_locales`): the extension name and store summary are now localized via `__MSG__` placeholders, with English (`en`, default) and Japanese (`ja`) messages. This unlocks a localized Japanese store listing in the Chrome Web Store dashboard after the next upload.
+
 ## [1.10.0] - 2026-07-12
 
 ### Added

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "Search Navigator – Keyboard shortcuts for Google & YouTube",
+    "description": "Extension name shown in the toolbar and Chrome Web Store."
+  },
+  "extDescription": {
+    "message": "Keyboard shortcuts for Google Search & YouTube. Move with j/k, switch tabs, open results — no mouse, no setup, no tracking.",
+    "description": "Store summary / short description (max 132 characters)."
+  }
+}

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,10 @@
+{
+  "extName": {
+    "message": "Search Navigator – Google と YouTube のキーボードショートカット",
+    "description": "Extension name shown in the toolbar and Chrome Web Store."
+  },
+  "extDescription": {
+    "message": "Google 検索と YouTube をキーボードで操作。j/k で移動、タブ切替、結果を開く。マウス不要・設定不要・追跡なし。",
+    "description": "Store summary / short description (max 132 characters)."
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
   "manifest_version": 3,
-  "name": "Search Navigator – Keyboard shortcuts for Google & YouTube",
+  "default_locale": "en",
+  "name": "__MSG_extName__",
   "short_name": "Search Navigator",
   "version": "1.10.0",
-  "description": "Keyboard shortcuts for Google Search & YouTube. Move with j/k, switch tabs, open results — no mouse, no setup, no tracking.",
+  "description": "__MSG_extDescription__",
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -66,6 +66,7 @@ export default [
         targets: [
           { src: 'manifest.json', dest: 'dist' },
           { src: 'icons/*.png', dest: 'dist' },
+          { src: '_locales', dest: 'dist' },
         ],
       }),
     ].filter(Boolean), // Filter out false values


### PR DESCRIPTION
## Why

The Chrome Web Store dashboard only shows a **localized-listing language selector** once the uploaded package declares `default_locale` and ships `_locales/<lang>/`. This extension had no i18n, so there was **no Japanese description field** to fill in. This PR adds the scaffolding.

## What

- `manifest.json`: `default_locale: "en"`; `name` and `description` now use `__MSG_extName__` / `__MSG_extDescription__`.
- `_locales/en/messages.json` — English name + summary (unchanged wording, so nothing changes for English users).
- `_locales/ja/messages.json` — Japanese name + summary (≤132 chars).
- `rollup.config.js`: copies `_locales/` into `dist/` on build.

## How to use after merge

1. Ship it in a release (bump to e.g. 1.11.0 + build the zip) and **re-upload** to the Chrome Web Store.
2. A **language switcher** then appears at the top of the *Store listing* tab.
3. Select **日本語**, then paste the Japanese **detailed description** (the longer body is entered per-locale in the dashboard — text is in `docs/growth-playbook.md`). Localized screenshots/promo video are optional there too.

Note: `name` + summary come from the package (`_locales`); the long detailed description is dashboard-only, so it isn't in this PR.

## Verification

- `tsc`/unit **84 passing** · prod build ✓ (dist/manifest uses `__MSG__`, `dist/_locales/{en,ja}/messages.json` emitted) · **E2E 11/11** — the suite loads the built extension, which proves Chrome resolves the i18n messages (a broken `__MSG__` would fail to load).

This is a follow-up to the 1.10.0 release and is intentionally separate (a package change, not part of the discovery work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)