### PR TITLE
fix(rating): show the rating prompt at most once per install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 - Internationalization (`_locales`): the extension name and store summary are now localized via `__MSG__` placeholders, with English (`en`, default) and Japanese (`ja`) messages. This unlocks a localized Japanese store listing in the Chrome Web Store dashboard after the next upload.
 
+### Fixed
+
+- Rating prompt now appears at most once per install. Previously, ignoring the toast (closing the tab without clicking) let it reappear on every later search page; it is now marked as shown the moment it is displayed.
+
 ## [1.10.0] - 2026-07-12
 
 ### Added

--- a/e2e/rating-prompt.spec.ts
+++ b/e2e/rating-prompt.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from './fixtures';
+import { HIGHLIGHT_SELECTOR, serveFixtures } from './helpers';
+import type { BrowserContext } from '@playwright/test';
+
+const GOOGLE_ALL_URL = 'https://www.google.com/search?q=github+closes+comment+pr';
+const TOAST = '#sn-rate-prompt';
+
+test.beforeEach(async ({ context }) => {
+  await serveFixtures(context, {
+    'https://www.google.com/search': '20250529_all_tokyo_10.html',
+  });
+});
+
+const serviceWorker = async (context: BrowserContext) => {
+  const [existing] = context.serviceWorkers();
+  return existing ?? (await context.waitForEvent('serviceworker'));
+};
+
+const seedRatingState = async (
+  context: BrowserContext,
+  state: { opens: number; status: string }
+) => {
+  const sw = await serviceWorker(context);
+  await sw.evaluate(
+    (s) =>
+      new Promise<void>((resolve) =>
+        chrome.storage.sync.set({ rating_state: s }, () => resolve())
+      ),
+    state
+  );
+};
+
+const persistedStatus = async (context: BrowserContext) => {
+  const sw = await serviceWorker(context);
+  return sw.evaluate(
+    () =>
+      new Promise<string | undefined>((resolve) =>
+        chrome.storage.sync.get('rating_state', (r) =>
+          resolve(r.rating_state?.status)
+        )
+      )
+  );
+};
+
+test('shows the rating prompt once past the threshold, then never again if ignored', async ({
+  context,
+  page,
+}) => {
+  await seedRatingState(context, { opens: 15, status: 'pending' });
+
+  await page.goto(GOOGLE_ALL_URL);
+  await expect(page.locator(TOAST)).toBeVisible();
+
+  // Showing the prompt must immediately mark it resolved, so that ignoring it
+  // (no click) never re-shows it on the next page load.
+  await expect.poll(() => persistedStatus(context)).toBe('dismissed');
+
+  await page.reload();
+  await expect(page.locator(HIGHLIGHT_SELECTOR)).toHaveCount(1); // init ran
+  await expect(page.locator(TOAST)).toHaveCount(0);
+});
+
+test('never shows once the user has rated', async ({ context, page }) => {
+  await seedRatingState(context, { opens: 30, status: 'rated' });
+
+  await page.goto(GOOGLE_ALL_URL);
+  await expect(page.locator(HIGHLIGHT_SELECTOR)).toHaveCount(1); // init ran
+  await expect(page.locator(TOAST)).toHaveCount(0);
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -53,6 +53,11 @@ import './style.scss';
     ratePromptHandled = true;
     if (!shouldShowRatePrompt(ratingState)) return;
     if (document.getElementById(RATE_PROMPT_TOAST_ID)) return;
+    // Ask at most once, ever. Persist that the prompt has been shown *now* so
+    // that ignoring it (leaving without clicking) never re-shows it on the next
+    // page load. Clicking "Rate" simply upgrades the status to 'rated'.
+    ratingState = markDismissed(ratingState);
+    void saveRatingState(storageSync, ratingState).catch(() => {});
     const toast = createRatePromptToast(theme, {
       onRate: () => {
         window.open(RATE_URL, '_blank', 'noopener');
@@ -61,8 +66,6 @@ import './style.scss';
         toast.remove();
       },
       onDismiss: () => {
-        ratingState = markDismissed(ratingState);
-        void saveRatingState(storageSync, ratingState).catch(() => {});
         toast.remove();
       },
     });


### PR DESCRIPTION
## The bug (thanks to a question during the HN launch)

The in-page rating toast only left the `pending` state when the user **clicked** a button (Rate / Not now). If a user just **ignored** it — closed the tab without clicking — the state stayed `pending`, so the toast **reappeared on every later search-page load**. A repeating nag, exactly what we don't want.

## Fix

Persist the resolved state the **moment the toast is shown**, so an ignored prompt never re-shows. Clicking "Rate" still upgrades the status to `rated`. Net effect: the prompt appears **at most once per install, ever**.

## Tests

New `e2e/rating-prompt.spec.ts` (loads the built extension, seeds `chrome.storage.sync` via the service worker):
- shows once past the threshold, then **never again after being ignored** (reload → no toast);
- **never shows once already rated**.

`tsc` ✓ · unit 84 ✓ · **E2E 13/13** ✓

## Known limitation

There is no Chrome API to detect whether a user already left a review directly on the store, so an already-reviewer may still see the prompt **once**. At-most-once is the best achievable bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)