### PR TITLE
chore: prepare release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-14
+
 ### Added
 
 - Internationalization (`_locales`): the extension name and store summary are now localized via `__MSG__` placeholders, with English (`en`, default) and Japanese (`ja`) messages. This unlocks a localized Japanese store listing in the Chrome Web Store dashboard after the next upload.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extName__",
   "short_name": "Search Navigator",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "__MSG_extDescription__",
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
Prepare the 1.11.0 release (same convention as prepare-1.10.0 / #104).

- Bump `manifest.json` 1.10.0 → 1.11.0.
- Finalize CHANGELOG under `## [1.11.0] - 2026-07-14`:
  - Added: `_locales` (en/ja) internationalization (#105) — unlocks a Japanese store listing.
  - Fixed: rating prompt now shows at most once per install (#106).

After merge: tag `v1.11.0`, GitHub release, and upload the built zip to the Chrome Web Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)