### PR TITLE
feat(popup): allow disabling individual shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+### Added
+
+- Individual shortcuts can now be disabled: press Backspace (or Delete) in a shortcut field in the popup to clear it, then Save. A cleared shortcut is stored as disabled and no longer reacts to any key. Requested in a Chrome Web Store review (2026-08-06, "How do I delete a shortcut?").
+
 ## [1.11.0] - 2026-07-14
 
 ### Added

--- a/__tests__/keymap-manager.test.ts
+++ b/__tests__/keymap-manager.test.ts
@@ -42,6 +42,56 @@ describe('createKeymapManager', () => {
     expect(manager.isKeyMatch(event, 'open_link')).toBe(true);
   });
 
+  it('should not match any key for a disabled (null) shortcut', async () => {
+    mockStorage.get.mockResolvedValue({
+      key_configs: { ...defaultKeyConfigs, move_up: null },
+    });
+
+    const manager = await createKeymapManager(mockStorage);
+
+    expect(manager.getKeyConfigs().move_up).toBeNull();
+    expect(
+      manager.isKeyMatch(
+        { key: 'k', ctrlKey: false, altKey: false, shiftKey: false, metaKey: false },
+        'move_up'
+      )
+    ).toBe(false);
+  });
+
+  it('should not match open_link when disabled (null)', async () => {
+    mockStorage.get.mockResolvedValue({
+      key_configs: { ...defaultKeyConfigs, open_link: null },
+    });
+
+    const manager = await createKeymapManager(mockStorage);
+
+    expect(
+      manager.isKeyMatch(
+        {
+          key: 'Enter',
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+          metaKey: false,
+        },
+        'open_link'
+      )
+    ).toBe(false);
+  });
+
+  it('should keep disabled (null) shortcuts disabled after merging with defaults', async () => {
+    mockStorage.get.mockResolvedValue({
+      key_configs: { ...defaultKeyConfigs, switch_to_shopping: null },
+    });
+
+    const manager = await createKeymapManager(mockStorage);
+    const configs = manager.getKeyConfigs();
+
+    expect(configs.switch_to_shopping).toBeNull();
+    // Other shortcuts are unaffected
+    expect(configs.move_down).toEqual(defaultKeyConfigs.move_down);
+  });
+
   it('should save key configs to storage', async () => {
     mockStorage.get.mockResolvedValue({});
     mockStorage.set.mockResolvedValue();

--- a/src/popup.html
+++ b/src/popup.html
@@ -7,6 +7,10 @@
   <body>
     <div class="container">
       <h2>Shortcut Settings</h2>
+      <p class="note">
+        Click a field and press a key to change a shortcut. Press Backspace to
+        disable it.
+      </p>
       <h3>Navigation</h3>
 
       <div class="shortcut-row">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,4 +1,4 @@
-import type { KeyConfigs } from './services';
+import type { KeyConfig, KeyConfigs } from './services';
 import {
   createKeymapManager,
   defaultKeyConfigs,
@@ -71,27 +71,35 @@ document.addEventListener('DOMContentLoaded', async () => {
       return el as HTMLInputElement;
     });
 
-    // Set the values using the helper function to convert KeyConfig to display string
-    moveUpInput.value = keyConfigToString(keyConfigs.move_up);
-    moveDownInput.value = keyConfigToString(keyConfigs.move_down);
-    openLinkInput.value = keyConfigToString(keyConfigs.open_link);
-    previousPageInput.value = keyConfigToString(keyConfigs.navigate_previous);
-    nextPageInput.value = keyConfigToString(keyConfigs.navigate_next);
-    switchToImageSearchInput.value = keyConfigToString(
+    // A disabled (null) shortcut is shown as an empty field
+    const toDisplayString = (
+      cfg: Pick<KeyConfig<string>, 'key'> | null
+    ): string => (cfg ? keyConfigToString(cfg) : '');
+
+    moveUpInput.value = toDisplayString(keyConfigs.move_up);
+    moveDownInput.value = toDisplayString(keyConfigs.move_down);
+    openLinkInput.value = toDisplayString(keyConfigs.open_link);
+    previousPageInput.value = toDisplayString(keyConfigs.navigate_previous);
+    nextPageInput.value = toDisplayString(keyConfigs.navigate_next);
+    switchToImageSearchInput.value = toDisplayString(
       keyConfigs.switch_to_image_search
     );
-    switchToAllSearchInput.value = keyConfigToString(
+    switchToAllSearchInput.value = toDisplayString(
       keyConfigs.switch_to_all_search
     );
-    switchToVideosInput.value = keyConfigToString(keyConfigs.switch_to_videos);
-    switchToShoppingInput.value = keyConfigToString(
+    switchToVideosInput.value = toDisplayString(keyConfigs.switch_to_videos);
+    switchToShoppingInput.value = toDisplayString(
       keyConfigs.switch_to_shopping
     );
-    switchToNewsInput.value = keyConfigToString(keyConfigs.switch_to_news);
-    switchToMapInput.value = keyConfigToString(keyConfigs.switch_to_map);
-    switchToYoutubeInput.value = keyConfigToString(
-      keyConfigs.switch_to_youtube
-    );
+    switchToNewsInput.value = toDisplayString(keyConfigs.switch_to_news);
+    switchToMapInput.value = toDisplayString(keyConfigs.switch_to_map);
+    switchToYoutubeInput.value = toDisplayString(keyConfigs.switch_to_youtube);
+
+    document
+      .querySelectorAll<HTMLInputElement>('.shortcut-input')
+      .forEach((input) => {
+        input.placeholder = input.value ? '' : 'None';
+      });
   }
 
   /**
@@ -127,6 +135,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (swallowKeys.has(event.key)) {
           event.preventDefault();
           return; // stay in the input, wait for a "real" key
+        }
+
+        // Backspace/Delete clears the binding: the shortcut is disabled on save
+        if (event.key === 'Backspace' || event.key === 'Delete') {
+          event.preventDefault();
+          input.value = '';
+          didCapture = true;
+          input.blur();
+          return;
         }
 
         // 1) whitelist test
@@ -183,11 +200,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       });
 
       input.addEventListener('blur', () => {
-        input.placeholder = '';
         if (!didCapture) {
           // restore original if no valid combo was captured
           input.value = originalValue;
         }
+        input.placeholder = input.value ? '' : 'None';
       });
     });
   }
@@ -271,8 +288,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       ).reduce(
         (acc, key) => {
           const el = inputs[key];
-          if (el?.value) {
-            acc[key] = stringToKeyConfig(el.value);
+          if (el) {
+            // An empty field means the user cleared the binding: save it as
+            // null (disabled) instead of falling back to the default key
+            acc[key] = el.value ? stringToKeyConfig(el.value) : null;
           }
           return acc;
         },

--- a/src/services/keymap-manager.ts
+++ b/src/services/keymap-manager.ts
@@ -1,24 +1,25 @@
 import type { ChromeStorage } from './chrome-storage';
 import type { KeyConfig } from './keymap-utils';
 
+// `null` means the shortcut is disabled: it never matches any key.
 export interface KeyConfigs<T extends string> {
-  move_up: KeyConfig<T>;
-  move_down: KeyConfig<T>;
-  open_link: Pick<KeyConfig<T>, 'key'>; // open link only needs the key
-  navigate_previous: KeyConfig<T>;
-  navigate_next: KeyConfig<T>;
+  move_up: KeyConfig<T> | null;
+  move_down: KeyConfig<T> | null;
+  open_link: Pick<KeyConfig<T>, 'key'> | null; // open link only needs the key
+  navigate_previous: KeyConfig<T> | null;
+  navigate_next: KeyConfig<T> | null;
   // Arrow key alternatives for navigation
-  arrow_move_up: KeyConfig<T>;
-  arrow_move_down: KeyConfig<T>;
-  arrow_navigate_previous: KeyConfig<T>;
-  arrow_navigate_next: KeyConfig<T>;
-  switch_to_image_search: KeyConfig<T>;
-  switch_to_all_search: KeyConfig<T>;
-  switch_to_videos: KeyConfig<T>;
-  switch_to_shopping: KeyConfig<T>;
-  switch_to_news: KeyConfig<T>;
-  switch_to_map: KeyConfig<T>;
-  switch_to_youtube: KeyConfig<T>;
+  arrow_move_up: KeyConfig<T> | null;
+  arrow_move_down: KeyConfig<T> | null;
+  arrow_navigate_previous: KeyConfig<T> | null;
+  arrow_navigate_next: KeyConfig<T> | null;
+  switch_to_image_search: KeyConfig<T> | null;
+  switch_to_all_search: KeyConfig<T> | null;
+  switch_to_videos: KeyConfig<T> | null;
+  switch_to_shopping: KeyConfig<T> | null;
+  switch_to_news: KeyConfig<T> | null;
+  switch_to_map: KeyConfig<T> | null;
+  switch_to_youtube: KeyConfig<T> | null;
 }
 
 export type Action = keyof KeyConfigs<string>;
@@ -157,7 +158,7 @@ export const createKeymapManager = async (
     isKeyMatch(e, action) {
       if (action === 'open_link') {
         const cfg = current[action];
-        return e.key === cfg.key;
+        return cfg ? e.key === cfg.key : false;
       }
       const cfg = current[action];
       return cfg


### PR DESCRIPTION
## What

Adds the ability to disable an individual shortcut instead of only remapping it. Press **Backspace** (or Delete) in a shortcut field in the popup to clear it, then Save — that action then no longer reacts to any key. Pressing a key in the field again reassigns it.

## Why

A Chrome Web Store review (2026-08-06) asked:

> How do I delete a shortcut? meaning removing the hot key?

This was not possible. Since this extension binds bare single keys (`j` `k` `s` `n` `m` `y` …) on Google search pages, wanting to turn one off — because it misfires or collides with another extension — is a reasonable ask.

Source of the "not possible" claim: implementation grep at the time of the review.

- The input field had no way to be cleared — Backspace hit the invalid-key branch and blurred, and the `blur` handler restored the previous value.
- Even if a field were empty, `saveKeyConfigs` built `{ ...defaultKeyConfigs, ...userOverrideConfigs }` and only wrote non-empty fields into the override, so an empty field silently fell back to the default key.

## Changes

- `src/services/keymap-manager.ts` — each entry of `KeyConfigs` is now `KeyConfig<T> | null`, where `null` means disabled. `isKeyMatch` returns `false` for a disabled action (the non-`open_link` branch already handled a falsy config; `open_link` needed the same guard).
- `src/popup.ts` — Backspace/Delete clears a field; an empty field is saved as an explicit `null` instead of falling back to the default; disabled shortcuts render as an empty field with a `None` placeholder.
- `src/popup.html` — one-line hint explaining how to change or disable a shortcut.
- `__tests__/keymap-manager.test.ts` — three tests: disabled regular action never matches, disabled `open_link` never matches, and `null` survives the merge-with-defaults on load.
- `CHANGELOG.md` — Unreleased entry.

## Notes for the reviewer

- **Storage compatibility**: existing users are unaffected. Stored configs are merged over `defaultKeyConfigs` on load, so keys absent from storage still pick up defaults; only an explicit `null` disables.
- `content.ts` and `background.ts` needed no changes — they go through `isKeyMatch`, so `null` propagates naturally.
- Arrow-key aliases (`arrow_move_up` etc.) remain non-configurable in the UI and keep their defaults, as before.
- The disable applies per action, so e.g. disabling `move_down` still leaves `arrow_move_down` (↓) working. If we'd rather have one control disable both, that's a follow-up — say the word.

## Verification

Source: run locally on this branch (measured, not recalled).

- `npx tsc --noEmit` — clean
- `npx jest` — 87 tests, 12 suites, all pass
- `pnpm run test:e2e` — 13 Playwright tests pass
- `npm run format:check` — clean
- Manual: loaded the built popup in a browser with a stubbed `chrome.storage.sync`/`chrome.runtime`. Clearing "Switch to Shopping" and saving wrote `switch_to_shopping: null` while every other binding was preserved; reopening showed an empty field with the `None` placeholder; pressing `p` reassigned it to `p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)