### PR TITLE
chore: prepare release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-13
+
 ### Added
 
 - Individual shortcuts can now be disabled: press Backspace (or Delete) in a shortcut field in the popup to clear it, then Save. A cleared shortcut is stored as disabled and no longer reacts to any key. Requested in a Chrome Web Store review (2026-08-06, "How do I delete a shortcut?").

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "default_locale": "en",
   "name": "__MSG_extName__",
   "short_name": "Search Navigator",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "__MSG_extDescription__",
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
## What

Release prep for **1.12.0**: bumps `manifest.json` to `1.12.0` and closes out the `Unreleased` changelog section under a `[1.12.0] - 2026-08-13` heading. No code changes.

## Contents of this release

One user-facing change, already merged:

- **#108 — individual shortcuts can be disabled.** Press Backspace (or Delete) in a shortcut field in the popup to clear it, then Save; that action stops reacting to any key. Answers a Chrome Web Store review from 2026-08-06 asking how to remove a hot key.

`git log 48ed5fd..main` confirms #108 is the only change since the 1.11.0 prep commit, so a minor bump is the right level.

## Verification

Source: run locally on this branch (measured).

- `npx jest` — 87 tests, 12 suites, all pass
- `npx tsc --noEmit` — clean
- `npm run format:check` — clean
- `ENV=prod rollup -c` — builds; `dist/manifest.json` carries `"version": "1.12.0"`
- Packaged `search-navigator-1.12.0.zip` from `dist/` excluding `*.map` — 16 files, matching the layout of the v1.11.0 release asset

## After merge

The remaining release steps follow the 1.11.0 precedent (tag on the merge commit, GitHub release with the changelog body, zip attached, then upload the same zip to the Chrome Web Store dashboard). I can run the tag and release steps on request — say the word and I'll do it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)